### PR TITLE
Update go2rtc configuration and service scripts

### DIFF
--- a/files/services/S50go2rtc
+++ b/files/services/S50go2rtc
@@ -6,7 +6,7 @@
 
 GO2RTC="/usr/data/go2rtc/go2rtc_linux_mipsel"
 PIDFILE="/var/run/go2rtc.pid"
-GO2RTC_ARGS="-d -c /usr/data/go2rtc/go2rtc.conf"
+GO2RTC_ARGS="-d -c /usr/data/go2rtc/go2rtc.yaml"
 
 case "$1" in
   start)
@@ -14,7 +14,7 @@ case "$1" in
 	start-stop-daemon -S -p "$PIDFILE" --exec "$GO2RTC" -- $GO2RTC_ARGS
 	;;
   stop)
-    echo "Stopping GO2go2rtcRTC..."
+    echo "Stopping go2rtc..."
 	start-stop-daemon -K -x "$GO2RTC" -p "$PIDFILE" -o
 	;;
   reload|force-reload)

--- a/scripts/go2rtc.sh
+++ b/scripts/go2rtc.sh
@@ -24,7 +24,7 @@ function install_go2rtc(){
       Y|y)
         echo -e "${white}"
         echo -e "Info: Downloading go2rtc..."
-        mkdir -p "$(dirname $GO2RTC_FILE)"
+        mkdir -p "$(dirname "$GO2RTC_FILE")"
         $HS_FILES/fixes/curl -L "$GO2RTC_URL" -o "$GO2RTC_FILE"
         chmod +x "$GO2RTC_FILE"
         echo -e "Info: Copying service file..."
@@ -52,7 +52,7 @@ function install_go2rtc(){
 }
 
 function remove_go2rtc(){
-  moonraker_nginx_message
+  go2rtc_message
   local yn
   while true; do
     remove_msg "Go2rtc" yn
@@ -62,7 +62,7 @@ function remove_go2rtc(){
         echo -e "Info: Stopping Go2rtc service..."
         stop_go2rtc
         echo -e "Info: Removing files..."
-        rm -f $GO2RTC_SERVICE_FILE $GO2RTC_CONFIG_FILE $GO2RTC_SERVICE_FILE
+        rm -f "$GO2RTC_SERVICE_FILE" "$GO2RTC_CONFIG_FILE" "$GO2RTC_FILE"
         ok_msg "Go2rtc has been removed successfully!"
         return;;
       N|n)

--- a/scripts/menu/K1C_2025/install_menu_K1C_2025.sh
+++ b/scripts/menu/K1C_2025/install_menu_K1C_2025.sh
@@ -103,7 +103,7 @@ function install_menu_k1c_2025() {
           run "install_gcode_shell_command" "install_menu_ui_k1c_2025"
         fi;;
       6)
-        if [ -f "$GO2RCT_FILE" ]; then
+        if [ -f "$GO2RTC_FILE" ]; then
           error_msg "Go2rtc is already installed!"
         else
           run "install_go2rtc" "install_menu_ui_k1c_2025"

--- a/scripts/menu/K1C_2025/remove_menu_K1C_2025.sh
+++ b/scripts/menu/K1C_2025/remove_menu_K1C_2025.sh
@@ -15,7 +15,7 @@ function remove_menu_ui_k1c_2025() {
   subtitle '•UTILITIES:'
   menu_option ' 4' 'Remove' 'Entware'
   menu_option ' 5' 'Remove' 'Klipper Gcode Shell Command'
-  menu_option ' 5' 'Remove' 'Go2rtc'
+  menu_option ' 6' 'Remove' 'Go2rtc'
 #  hr
 #  subtitle '•IMPROVEMENTS:'
 #  disabled_menu_option ' 6' 'Remove' 'Klipper Adaptive Meshing & Purging'


### PR DESCRIPTION
## Summary

Fixes several small Go2rtc integration issues for K1C 2025 support.

## Changes

- Fix Go2rtc service config path from `go2rtc.conf` to the installed `go2rtc.yaml`.
- Fix typo in Go2rtc service stop message.
- Fix `GO2RCT_FILE` typo to `GO2RTC_FILE` in the K1C 2025 install menu.
- Fix duplicate remove menu number so Go2rtc is shown as option `6`.
- Use the Go2rtc message screen when removing Go2rtc.
- Quote `GO2RTC_FILE` when resolving its directory.
- Remove the Go2rtc binary during uninstall, not just the service/config files.