### PR TITLE
Add K1C 2025 support for Go2rtc and Moonraker Nginx configuration

### DIFF
--- a/files/camera-settings/camera-settings-k1c-2025.cfg
+++ b/files/camera-settings/camera-settings-k1c-2025.cfg
@@ -1,0 +1,73 @@
+########################################
+# K1C 2025 Camera Settings Control
+########################################
+
+[gcode_shell_command v4l2-ctl]
+command: v4l2-ctl
+timeout: 5.0
+verbose: True
+
+[gcode_macro CAM_SETTINGS]
+description: Show current camera settings
+gcode:
+    RUN_SHELL_COMMAND CMD=v4l2-ctl PARAMS="-d /dev/video0 --list-ctrls"
+
+[gcode_macro CAM_BRIGHTNESS]
+description: min=0 / max=255
+gcode:
+    {% set brightness = params.BRIGHTNESS|default(128) %}
+    RUN_SHELL_COMMAND CMD=v4l2-ctl PARAMS="-d /dev/video0 --set-ctrl brightness="{brightness}
+
+[gcode_macro CAM_CONTRAST]
+description: min=0 / max=255
+gcode:
+    {% set contrast = params.CONTRAST|default(128) %}
+    RUN_SHELL_COMMAND CMD=v4l2-ctl PARAMS="-d /dev/video0 --set-ctrl contrast="{contrast}
+
+[gcode_macro CAM_SATURATION]
+description: min=0 / max=255
+gcode:
+    {% set saturation = params.SATURATION|default(128) %}
+    RUN_SHELL_COMMAND CMD=v4l2-ctl PARAMS="-d /dev/video0 --set-ctrl saturation="{saturation}
+
+[gcode_macro CAM_GAIN]
+description: min=0 / max=100
+gcode:
+    {% set gain = params.GAIN|default(5) %}
+    RUN_SHELL_COMMAND CMD=v4l2-ctl PARAMS="-d /dev/video0 --set-ctrl gain="{gain}
+
+[gcode_macro CAM_POWER_LINE_FREQUENCY]
+description: disabled=0 / 50hz=1 / 60hz=2
+gcode:
+    {% set power_line_frequency = params.POWER_LINE_FREQUENCY|default(1) %}
+    RUN_SHELL_COMMAND CMD=v4l2-ctl PARAMS="-d /dev/video0 --set-ctrl power_line_frequency="{power_line_frequency}
+
+[gcode_macro CAM_WHITE_BALANCE_TEMPERATURE_AUTO]
+description: disable=0 / enable=1
+gcode:
+    {% set white_balance_temperature_auto = params.WHITE_BALANCE_TEMPERATURE_AUTO|default(1) %}
+    RUN_SHELL_COMMAND CMD=v4l2-ctl PARAMS="-d /dev/video0 --set-ctrl white_balance_temperature_auto="{white_balance_temperature_auto}
+
+[gcode_macro CAM_WHITE_BALANCE_TEMPERATURE]
+description: min=0 / max=255
+gcode:
+    {% set white_balance_temperature = params.WHITE_BALANCE_TEMPERATURE|default(128) %}
+    RUN_SHELL_COMMAND CMD=v4l2-ctl PARAMS="-d /dev/video0 --set-ctrl white_balance_temperature="{white_balance_temperature}
+
+[gcode_macro CAM_SHARPNESS]
+description: min=0 / max=255
+gcode:
+    {% set sharpness = params.SHARPNESS|default(128) %}
+    RUN_SHELL_COMMAND CMD=v4l2-ctl PARAMS="-d /dev/video0 --set-ctrl sharpness="{sharpness}
+
+[gcode_macro CAM_EXPOSURE_AUTO]
+description: auto=0 / manual=1
+gcode:
+    {% set exposure_auto = params.EXPOSURE_AUTO|default(0) %}
+    RUN_SHELL_COMMAND CMD=v4l2-ctl PARAMS="-d /dev/video0 --set-ctrl exposure_auto="{exposure_auto}
+
+[gcode_macro CAM_EXPOSURE_ABSOLUTE]
+description: min=0 / max=6500
+gcode:
+    {% set exposure_absolute = params.EXPOSURE_ABSOLUTE|default(100) %}
+    RUN_SHELL_COMMAND CMD=v4l2-ctl PARAMS="-d /dev/video0 --set-ctrl exposure_auto=1 --set-ctrl exposure_absolute="{exposure_absolute}

--- a/files/services/CS55klipper_service_minimal
+++ b/files/services/CS55klipper_service_minimal
@@ -1,0 +1,56 @@
+#!/bin/sh
+#
+# Klipper service (minimal, K1C 2025+ apps layout).
+# - No copy_config / update_config on start (Helper Script "Prevent updating" goal).
+# - No mcu_reset via /etc/init.d/S57klipper_mcu — that init script is not used on
+#   this platform; MCU maintenance is via /usr/apps/usr/bin/*_klipper_mcu_restart.sh.
+#
+
+USER_DATA="/usr/data"
+PROG="/usr/share/klippy-env/bin/python"
+PY_SCRIPT="/usr/share/klipper/klippy/klippy.py"
+PRINTER_DATA_DIR="$USER_DATA/printer_data"
+PRINTER_CONFIG_DIR="$PRINTER_DATA_DIR/config"
+PRINTER_LOGS_DIR="$PRINTER_DATA_DIR/logs"
+PID_FILE="/home/creality/run/klippy.pid"
+
+if [ ! -f "$PY_SCRIPT" ]; then
+  PY_SCRIPT="/usr/share/klipper/klippy/klippy.pyc"
+fi
+
+start() {
+  mkdir -p "$PRINTER_DATA_DIR" "$PRINTER_CONFIG_DIR" "$PRINTER_LOGS_DIR" \
+    "$(dirname "$PID_FILE")" 2>/dev/null
+  HOME="/root" start-stop-daemon -S -q -b -m -p "$PID_FILE" \
+    --exec "$PROG" -- "$PY_SCRIPT" \
+    "$PRINTER_CONFIG_DIR"/printer.cfg \
+    -l "$PRINTER_LOGS_DIR"/klippy.log \
+    -a "/tmp/klippy_uds"
+}
+
+stop() {
+  start-stop-daemon -K -q -p "$PID_FILE"
+}
+
+restart() {
+  stop
+  start
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  restart|reload)
+    restart
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart}"
+    exit 1
+    ;;
+esac
+
+exit $?

--- a/files/services/S50builtin_camera-k1c-2025
+++ b/files/services/S50builtin_camera-k1c-2025
@@ -14,6 +14,7 @@ case "$1" in
     echo "Stopping Built-in Camera..."
     PIDS=$(ps | grep '[m]jpg_streamer' | grep 'output_http.so -p 8080' | awk '{print $1}')
     [ -n "$PIDS" ] && kill $PIDS
+    exit 0
     ;;
   restart|reload)
     "$0" stop

--- a/files/services/S50builtin_camera-k1c-2025
+++ b/files/services/S50builtin_camera-k1c-2025
@@ -1,0 +1,28 @@
+#!/bin/sh
+# K1C 2025 Built-in Camera Service
+
+case "$1" in
+  start)
+    echo "Starting Built-in Camera..."
+    if [ ! -e /dev/video0 ]; then
+      echo "Error: Built-in camera /dev/video0 not found!"
+      exit 1
+    fi
+    /opt/bin/mjpg_streamer -b -i "/opt/lib/mjpg-streamer/input_uvc.so -d /dev/video0 -r 1280x720 -f 15" -o "/opt/lib/mjpg-streamer/output_http.so -p 8080"
+    ;;
+  stop)
+    echo "Stopping Built-in Camera..."
+    PIDS=$(ps | grep '[m]jpg_streamer' | grep 'output_http.so -p 8080' | awk '{print $1}')
+    [ -n "$PIDS" ] && kill $PIDS
+    ;;
+  restart|reload)
+    "$0" stop
+    sleep 1
+    "$0" start
+    ;;
+  *)
+    echo "Usage: /etc/init.d/S50builtin_camera {start|stop|restart}"
+    exit 1
+esac
+
+exit $?

--- a/files/services/S50usb_camera-k1c-2025
+++ b/files/services/S50usb_camera-k1c-2025
@@ -20,6 +20,7 @@ case "$1" in
     echo "Stopping USB Camera..."
     PIDS=$(ps | grep '[m]jpg_streamer' | grep 'output_http.so -p 808[2-9]' | awk '{print $1}')
     [ -n "$PIDS" ] && kill $PIDS
+    exit 0
     ;;
   restart|reload)
     "$0" stop

--- a/files/services/S50usb_camera-k1c-2025
+++ b/files/services/S50usb_camera-k1c-2025
@@ -4,7 +4,7 @@
 case "$1" in
   start)
     echo "Starting USB Camera..."
-    PORT=8081
+    PORT=8082
     BUILTIN_DEV="/dev/video0"
     V4L_DEVS=$(v4l2-ctl --list-devices | grep -A1 usb | sed 's/^[[:space:]]*//g' | grep '^/dev' | grep -v "^$BUILTIN_DEV$")
     if [ "x$V4L_DEVS" = "x" ]; then
@@ -18,7 +18,7 @@ case "$1" in
     ;;
   stop)
     echo "Stopping USB Camera..."
-    PIDS=$(ps | grep '[m]jpg_streamer' | grep 'output_http.so -p 808[1-9]' | awk '{print $1}')
+    PIDS=$(ps | grep '[m]jpg_streamer' | grep 'output_http.so -p 808[2-9]' | awk '{print $1}')
     [ -n "$PIDS" ] && kill $PIDS
     ;;
   restart|reload)

--- a/files/services/S50usb_camera-k1c-2025
+++ b/files/services/S50usb_camera-k1c-2025
@@ -1,0 +1,34 @@
+#!/bin/sh
+# K1C 2025 USB Camera Service
+
+case "$1" in
+  start)
+    echo "Starting USB Camera..."
+    PORT=8081
+    BUILTIN_DEV="/dev/video0"
+    V4L_DEVS=$(v4l2-ctl --list-devices | grep -A1 usb | sed 's/^[[:space:]]*//g' | grep '^/dev' | grep -v "^$BUILTIN_DEV$")
+    if [ "x$V4L_DEVS" = "x" ]; then
+      echo "Error: No third party USB camera found!"
+      exit 1
+    fi
+    for V4L_DEV in $V4L_DEVS; do
+      /opt/bin/mjpg_streamer -b -i "/opt/lib/mjpg-streamer/input_uvc.so -d $V4L_DEV -r 1280x720 -f 15" -o "/opt/lib/mjpg-streamer/output_http.so -p $PORT"
+      PORT=`expr $PORT + 1`
+    done
+    ;;
+  stop)
+    echo "Stopping USB Camera..."
+    PIDS=$(ps | grep '[m]jpg_streamer' | grep 'output_http.so -p 808[1-9]' | awk '{print $1}')
+    [ -n "$PIDS" ] && kill $PIDS
+    ;;
+  restart|reload)
+    "$0" stop
+    sleep 1
+    "$0" start
+    ;;
+  *)
+    echo "Usage: /etc/init.d/S50usb_camera {start|stop|restart}"
+    exit 1
+esac
+
+exit $?

--- a/scripts/camera_settings_control.sh
+++ b/scripts/camera_settings_control.sh
@@ -28,7 +28,9 @@ function install_camera_settings_control(){
           mkdir -p "$HS_CONFIG_FOLDER"
         fi
         echo -e "Info: Linking file..."
-        if v4l2-ctl --list-devices | grep -q 'CCX2F3298'; then
+        if [ "$model" = "K1C_2025" ]; then
+          cp "$CAMERA_SETTINGS_K1C_2025_URL" "$HS_CONFIG_FOLDER"/camera-settings.cfg
+        elif v4l2-ctl --list-devices | grep -q 'CCX2F3298'; then
           cp "$CAMERA_SETTINGS_NEBULA_URL" "$HS_CONFIG_FOLDER"/camera-settings.cfg
         else
           cp "$CAMERA_SETTINGS_URL" "$HS_CONFIG_FOLDER"/camera-settings.cfg
@@ -37,7 +39,13 @@ function install_camera_settings_control(){
           echo -e "Info: Camera Settings configurations are already enabled in printer.cfg file..."
         else
           echo -e "Info: Adding Camera Settings configurations in printer.cfg file..."
-          sed -i '/\[include printer_params\.cfg\]/a \[include Helper-Script/camera-settings\.cfg\]' "$PRINTER_CFG"
+          if grep -q "\[include printer_params\.cfg\]" "$PRINTER_CFG"; then
+            sed -i '/\[include printer_params\.cfg\]/a \[include Helper-Script/camera-settings\.cfg\]' "$PRINTER_CFG"
+          elif grep -q "#\*# <---------------------- SAVE_CONFIG ---------------------->" "$PRINTER_CFG"; then
+            sed -i '/#\*# <---------------------- SAVE_CONFIG ---------------------->/i \[include Helper-Script/camera-settings\.cfg\]' "$PRINTER_CFG"
+          else
+            echo "[include Helper-Script/camera-settings.cfg]" >> "$PRINTER_CFG"
+          fi
         fi
         echo -e "Info: Restarting Klipper service..."
         restart_klipper

--- a/scripts/entware.sh
+++ b/scripts/entware.sh
@@ -61,6 +61,8 @@ function install_entware(){
           k1c_2025_opt_mount
           $HS_FILES/fixes/curl -L "https://bin.entware.net/mipselsf-k3.4/installer/generic.sh" | sh
           export PATH=/opt/bin:/opt/sbin:$PATH
+          sed -i '1s|.*|src/gz entware http://bin.tranducanh.com/mipselsf-k3.4|' /opt/etc/opkg.conf
+          opkg update
 
           opkg install openssh-sftp-server
           #Manually link. Will be done on boot by S56entware

--- a/scripts/go2rtc.sh
+++ b/scripts/go2rtc.sh
@@ -14,6 +14,54 @@ function go2rtc_message(){
   bottom_line
 }
 
+function configure_go2rtc_k1c_2025(){
+  local nginx_conf
+
+  if [ -f "$MOONRAKER_CFG" ]; then
+    if ! grep -q '^\[webcam chassis\]' "$MOONRAKER_CFG"; then
+      echo -e "Info: Adding K1C 2025 chassis camera to moonraker.conf..."
+      cat >> "$MOONRAKER_CFG" <<EOF
+
+[webcam chassis]
+enabled: True
+location: printer
+service: ipstream
+target_fps: 15
+target_fps_idle: 5
+stream_url: /go2rtc/api/stream.mp4?src=chassis
+snapshot_url: /go2rtc/api/frame.jpeg?src=chassis
+flip_horizontal: False
+flip_vertical: False
+rotation: 0
+aspect_ratio: 16:9
+EOF
+    else
+      echo -e "Info: K1C 2025 chassis camera is already configured in moonraker.conf..."
+      sed -i '/^\[webcam chassis\]/,/^\[/ s|^stream_url:.*|stream_url: /go2rtc/api/stream.mp4?src=chassis|' "$MOONRAKER_CFG"
+      sed -i '/^\[webcam chassis\]/,/^\[/ s|^snapshot_url:.*|snapshot_url: /go2rtc/api/frame.jpeg?src=chassis|' "$MOONRAKER_CFG"
+    fi
+  fi
+
+  for nginx_conf in "$NGINX_FOLDER"/nginx/nginx.conf /etc/nginx/nginx.conf; do
+    if [ -f "$nginx_conf" ]; then
+      if ! grep -q 'location /go2rtc/' "$nginx_conf"; then
+        echo -e "Info: Adding Nginx proxy for go2rtc in $nginx_conf..."
+        sed -i '/location ~ \^\/(printer|api|access|machine|server)\/ {/i\
+        location /go2rtc/ {\
+            proxy_pass http://127.0.0.1:1984/;\
+            proxy_http_version 1.1;\
+            proxy_set_header Host $http_host;\
+            proxy_set_header X-Real-IP $remote_addr;\
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\
+            proxy_buffering off;\
+        }\
+\
+' "$nginx_conf"
+      fi
+    fi
+  done
+}
+
 
 function install_go2rtc(){
   go2rtc_message
@@ -36,11 +84,17 @@ function install_go2rtc(){
         if [ ! -f "$GO2RTC_CONFIG_FILE" ]; then
           cp "$GO2RTC_CONFIG_FILE_URL" "$GO2RTC_CONFIG_FILE"
         fi
+        if [ "$model" = "K1C_2025" ] && [ -d "$MOONRAKER_FOLDER" ]; then
+          configure_go2rtc_k1c_2025
+          stop_moonraker
+          start_moonraker
+          restart_nginx
+        fi
         echo -e "Info: Starting Go2rtc service..."
         start_go2rtc
         ok_msg "Go2rtc has been installed successfully!"
-        ok_msg "Stream URL: http://PRINTER_IP:1984/stream.mp4?src=chassis"
-        ok_msg "Snapshot URL: http://PRINTER_IP:1984/frame.jpeg?src=chassis"
+        ok_msg "Stream URL: /go2rtc/api/stream.mp4?src=chassis"
+        ok_msg "Snapshot URL: /go2rtc/api/frame.jpeg?src=chassis"
         return;;
       N|n)
         error_msg "Installation canceled!"

--- a/scripts/go2rtc.sh
+++ b/scripts/go2rtc.sh
@@ -36,9 +36,7 @@ rotation: 0
 aspect_ratio: 16:9
 EOF
     else
-      echo -e "Info: K1C 2025 chassis camera is already configured in moonraker.conf..."
-      sed -i '/^\[webcam chassis\]/,/^\[/ s|^stream_url:.*|stream_url: /go2rtc/api/stream.mp4?src=chassis|' "$MOONRAKER_CFG"
-      sed -i '/^\[webcam chassis\]/,/^\[/ s|^snapshot_url:.*|snapshot_url: /go2rtc/api/frame.jpeg?src=chassis|' "$MOONRAKER_CFG"
+      echo -e "Info: K1C 2025 chassis camera is already configured in moonraker.conf. Keeping existing camera URLs..."
     fi
   fi
 

--- a/scripts/menu/K1C_2025/info_menu_K1C_2025.sh
+++ b/scripts/menu/K1C_2025/info_menu_K1C_2025.sh
@@ -60,6 +60,7 @@ function info_menu_ui_k1c_2025() {
   info_line "$(check_file_k1c_2025 "$TIMELAPSE_FILE")" 'Moonraker Timelapse'
   info_line "$(check_file_k1c_2025 "$CAMERA_SETTINGS_FILE")" 'Camera Settings Control'
   info_line "$(check_file_k1c_2025 "$USB_CAMERA_FILE")" 'USB Camera Support'
+  info_line "$(check_file_k1c_2025 "$BUILTIN_CAMERA_FILE")" 'Built-in Camera Fix'
   hr
   subtitle '•REMOTE ACCESS:'
   info_line "$(check_folder_k1c_2025 "$OCTOEVERYWHERE_FOLDER")" 'OctoEverywhere'

--- a/scripts/menu/K1C_2025/install_menu_K1C_2025.sh
+++ b/scripts/menu/K1C_2025/install_menu_K1C_2025.sh
@@ -18,6 +18,7 @@ function install_menu_ui_k1c_2025() {
   menu_option ' 6' 'Install' 'Go2rtc'
   menu_option ' 7' 'Install' 'USB Camera Support'
   menu_option ' 8' 'Install' 'Built-in Camera Fix'
+  menu_option ' 9' 'Install' 'Camera Settings Control'
 #  hr
 #  subtitle '•IMPROVEMENTS:'
 #  disabled_menu_option ' 6' 'Install' 'Klipper Adaptive Meshing & Purging'
@@ -131,6 +132,14 @@ function install_menu_k1c_2025() {
           error_msg "Moonraker and Nginx are needed, please install them first!"
         else
           run "install_builtin_camera" "install_menu_ui_k1c_2025"
+        fi;;
+      9)
+        if [ -f "$CAMERA_SETTINGS_FILE" ]; then
+          error_msg "Camera Settings Control is already installed!"
+        elif [ ! -f "$KLIPPER_SHELL_FILE" ]; then
+          error_msg "Klipper Gcode Shell Command is needed, please install it first!"
+        else
+          run "install_camera_settings_control" "install_menu_ui_k1c_2025"
         fi;;
 #      7)
 #        disabled_feature;;

--- a/scripts/menu/K1C_2025/install_menu_K1C_2025.sh
+++ b/scripts/menu/K1C_2025/install_menu_K1C_2025.sh
@@ -15,6 +15,8 @@ function install_menu_ui_k1c_2025() {
   subtitle '•UTILITIES:'
   menu_option ' 4' 'Install' 'Entware'
   menu_option ' 5' 'Install' 'Klipper Gcode Shell Command !!!UNTESTED!!!'
+  hr
+  subtitle '•CAMERA:'
   menu_option ' 6' 'Install' 'Go2rtc'
   menu_option ' 7' 'Install' 'USB Camera Support'
   menu_option ' 8' 'Install' 'Built-in Camera Fix'

--- a/scripts/menu/K1C_2025/install_menu_K1C_2025.sh
+++ b/scripts/menu/K1C_2025/install_menu_K1C_2025.sh
@@ -16,6 +16,8 @@ function install_menu_ui_k1c_2025() {
   menu_option ' 4' 'Install' 'Entware'
   menu_option ' 5' 'Install' 'Klipper Gcode Shell Command !!!UNTESTED!!!'
   menu_option ' 6' 'Install' 'Go2rtc'
+  menu_option ' 7' 'Install' 'USB Camera Support'
+  menu_option ' 8' 'Install' 'Built-in Camera Fix'
 #  hr
 #  subtitle '•IMPROVEMENTS:'
 #  disabled_menu_option ' 6' 'Install' 'Klipper Adaptive Meshing & Purging'
@@ -107,6 +109,28 @@ function install_menu_k1c_2025() {
           error_msg "Go2rtc is already installed!"
         else
           run "install_go2rtc" "install_menu_ui_k1c_2025"
+        fi;;
+      7)
+        if [ -f "$USB_CAMERA_FILE" ]; then
+          error_msg "Camera USB Support is already installed!"
+        elif [ ! -f "$ENTWARE_FILE" ]; then
+          error_msg "Entware is needed, please install it first!"
+        elif [ ! -d "$MOONRAKER_FOLDER" ] || [ ! -d "$NGINX_FOLDER" ]; then
+          error_msg "Moonraker and Nginx are needed, please install them first!"
+        elif ! v4l2-ctl --list-devices | grep -A1 usb | sed 's/^[[:space:]]*//g' | grep '^/dev' | grep -vq '^/dev/video0$'; then
+          error_msg "No third party USB camera found!"
+        else
+          run "install_usb_camera" "install_menu_ui_k1c_2025"
+        fi;;
+      8)
+        if [ -f "$BUILTIN_CAMERA_FILE" ]; then
+          error_msg "Built-in Camera Fix is already installed!"
+        elif [ ! -f "$ENTWARE_FILE" ]; then
+          error_msg "Entware is needed, please install it first!"
+        elif [ ! -d "$MOONRAKER_FOLDER" ] || [ ! -d "$NGINX_FOLDER" ]; then
+          error_msg "Moonraker and Nginx are needed, please install them first!"
+        else
+          run "install_builtin_camera" "install_menu_ui_k1c_2025"
         fi;;
 #      7)
 #        disabled_feature;;

--- a/scripts/menu/K1C_2025/remove_menu_K1C_2025.sh
+++ b/scripts/menu/K1C_2025/remove_menu_K1C_2025.sh
@@ -18,6 +18,7 @@ function remove_menu_ui_k1c_2025() {
   menu_option ' 6' 'Remove' 'Go2rtc'
   menu_option ' 7' 'Remove' 'USB Camera Support'
   menu_option ' 8' 'Remove' 'Built-in Camera Fix'
+  menu_option ' 9' 'Remove' 'Camera Settings Control'
 #  hr
 #  subtitle '•IMPROVEMENTS:'
 #  disabled_menu_option ' 6' 'Remove' 'Klipper Adaptive Meshing & Purging'
@@ -142,6 +143,12 @@ function remove_menu_k1c_2025() {
           error_msg "Built-in Camera Fix is not installed!"
         else
           run "remove_builtin_camera" "remove_menu_ui_k1c_2025"
+        fi;;
+      9)
+        if [ ! -f "$CAMERA_SETTINGS_FILE" ]; then
+          error_msg "Camera Settings Control is not installed!"
+        else
+          run "remove_camera_settings_control" "remove_menu_ui_k1c_2025"
         fi;;
 
 #      6)

--- a/scripts/menu/K1C_2025/remove_menu_K1C_2025.sh
+++ b/scripts/menu/K1C_2025/remove_menu_K1C_2025.sh
@@ -15,6 +15,8 @@ function remove_menu_ui_k1c_2025() {
   subtitle '•UTILITIES:'
   menu_option ' 4' 'Remove' 'Entware'
   menu_option ' 5' 'Remove' 'Klipper Gcode Shell Command'
+  hr
+  subtitle '•CAMERA:'
   menu_option ' 6' 'Remove' 'Go2rtc'
   menu_option ' 7' 'Remove' 'USB Camera Support'
   menu_option ' 8' 'Remove' 'Built-in Camera Fix'

--- a/scripts/menu/K1C_2025/remove_menu_K1C_2025.sh
+++ b/scripts/menu/K1C_2025/remove_menu_K1C_2025.sh
@@ -16,6 +16,8 @@ function remove_menu_ui_k1c_2025() {
   menu_option ' 4' 'Remove' 'Entware'
   menu_option ' 5' 'Remove' 'Klipper Gcode Shell Command'
   menu_option ' 6' 'Remove' 'Go2rtc'
+  menu_option ' 7' 'Remove' 'USB Camera Support'
+  menu_option ' 8' 'Remove' 'Built-in Camera Fix'
 #  hr
 #  subtitle '•IMPROVEMENTS:'
 #  disabled_menu_option ' 6' 'Remove' 'Klipper Adaptive Meshing & Purging'
@@ -99,6 +101,8 @@ function remove_menu_k1c_2025() {
           error_msg "Entware is needed to use Moonraker Obico, please uninstall it first!"
         elif [ -f "$USB_CAMERA_FILE" ]; then
           error_msg "Entware is needed to use USB Camera Support, please uninstall it first!"
+        elif [ -f "$BUILTIN_CAMERA_FILE" ]; then
+          error_msg "Entware is needed to use Built-in Camera Fix, please uninstall it first!"
         else
           run "remove_entware" "remove_menu_ui_k1c_2025"
         fi;;
@@ -126,6 +130,18 @@ function remove_menu_k1c_2025() {
           error_msg "Go2rtc is not installed!"
         else
           run "remove_go2rtc" "remove_menu_ui_k1c_2025"
+        fi;;
+      7)
+        if [ ! -f "$USB_CAMERA_FILE" ]; then
+          error_msg "USB Camera Support is not installed!"
+        else
+          run "remove_usb_camera" "remove_menu_ui_k1c_2025"
+        fi;;
+      8)
+        if [ ! -f "$BUILTIN_CAMERA_FILE" ]; then
+          error_msg "Built-in Camera Fix is not installed!"
+        else
+          run "remove_builtin_camera" "remove_menu_ui_k1c_2025"
         fi;;
 
 #      6)

--- a/scripts/menu/K1C_2025/tools_menu_K1C_2025.sh
+++ b/scripts/menu/K1C_2025/tools_menu_K1C_2025.sh
@@ -11,8 +11,8 @@ function tools_menu_ui_k1c_2025() {
   menu_option ' 2' 'Allow updating' 'Klipper configuration files'
   disabled_menu_option ' 3' 'Fix' 'printing Gcode files from folder'
   hr
-  disabled_menu_option ' 4' 'Enable' 'camera settings in Moonraker'
-  disabled_menu_option ' 5' 'Disable' 'camera settings in Moonraker'
+  menu_option ' 4' 'Enable' 'camera settings in Moonraker'
+  menu_option ' 5' 'Disable' 'camera settings in Moonraker'
   hr
   menu_option ' 6' 'Restart' 'Nginx service'
   menu_option ' 7' 'Restart' 'Moonraker service'
@@ -61,19 +61,19 @@ function tools_menu_k1c_2025() {
 #          run "printing_gcode_from_folder" "tools_menu_ui_k1c_2025"
 #        fi;;
       4)
-        disabled_feature;;
-#        if grep -q "^\[webcam Camera\]$" "$MOONRAKER_CFG"; then
-#          error_msg "Camera settings are alredy enabled in Moonraker!"
-#        else
-#          run "enable_camera_settings" "tools_menu_ui_k1c_2025"
-#        fi;;
+        if [ ! -f "$BUILTIN_CAMERA_FILE" ] && [ ! -f "$USB_CAMERA_FILE" ]; then
+          error_msg "Built-in Camera Fix or USB Camera Support is needed, please install one first!"
+        elif grep -q "^\[webcam chassis\]\|^\[webcam usb\]" "$MOONRAKER_CFG"; then
+          error_msg "Camera settings are already enabled in Moonraker!"
+        else
+          run "enable_camera_settings" "tools_menu_ui_k1c_2025"
+        fi;;
       5)
-        disabled_feature;;
-#        if grep -q "^#\[webcam Camera\]" "$MOONRAKER_CFG"; then
-#          error_msg "Camera settings are alredy disabled in Moonraker!"
-#        else
-#          run "disable_camera_settings" "tools_menu_ui_k1c_2025"
-#        fi;;
+        if ! grep -q "^\[webcam chassis\]\|^\[webcam usb\]" "$MOONRAKER_CFG"; then
+          error_msg "Camera settings are already disabled in Moonraker!"
+        else
+          run "disable_camera_settings" "tools_menu_ui_k1c_2025"
+        fi;;
       6)
         if [ ! -d "$NGINX_FOLDER" ]; then
           error_msg "Nginx is not installed!"

--- a/scripts/menu/K1C_2025/tools_menu_K1C_2025.sh
+++ b/scripts/menu/K1C_2025/tools_menu_K1C_2025.sh
@@ -16,7 +16,7 @@ function tools_menu_ui_k1c_2025() {
   hr
   menu_option ' 6' 'Restart' 'Nginx service'
   menu_option ' 7' 'Restart' 'Moonraker service'
-  disabled_menu_option ' 8' 'Restart' 'Klipper service'
+  menu_option ' 8' 'Restart' 'Klipper service'
   hr
   menu_option ' 9' 'Update' 'Entware packages'
   hr
@@ -87,12 +87,11 @@ function tools_menu_k1c_2025() {
           run "restart_moonraker_action" "tools_menu_ui_k1c_2025"
         fi;;
       8)
-        disabled_feature;;
-#        if [ ! -f "$INITD_FOLDER"/S55klipper_service ]; then
-#          error_msg "Klipper service is not present!"
-#        else
-#          run "restart_klipper_action" "tools_menu_ui_k1c_2025"
-#        fi;;
+        if [ ! -f "$INITD_FOLDER"/CS55klipper_service ] && [ ! -f "$INITD_FOLDER"/S55klipper_service ]; then
+          error_msg "Klipper service is not present!"
+        else
+          run "restart_klipper_action" "tools_menu_ui_k1c_2025"
+        fi;;
       9)
         if [ ! -f "$ENTWARE_FILE" ]; then
           error_msg "Entware is not installed!"

--- a/scripts/menu/K1C_2025/tools_menu_K1C_2025.sh
+++ b/scripts/menu/K1C_2025/tools_menu_K1C_2025.sh
@@ -44,13 +44,13 @@ function tools_menu_k1c_2025() {
     read -p " ${white}Type your choice and validate with Enter: ${yellow}" tools_menu_opt
     case "${tools_menu_opt}" in
       1)
-        if [ -f "$INITD_FOLDER"/disabled.S55klipper_service ]; then
+        if [ -f "$INITD_FOLDER"/disabled.S55klipper_service ] || [ -f "$INITD_FOLDER"/disabled.CS55klipper_service ]; then
           error_msg "Updating Klipper configuration files is already prevented!"
         else
           run "prevent_updating_klipper_files" "tools_menu_ui_k1c_2025"
         fi;;
       2)
-        if [ ! -f "$INITD_FOLDER"/disabled.S55klipper_service ]; then
+        if [ ! -f "$INITD_FOLDER"/disabled.S55klipper_service ] && [ ! -f "$INITD_FOLDER"/disabled.CS55klipper_service ]; then
           error_msg "Updating Klipper configuration files is already allowed!"
         else
           run "allow_updating_klipper_files" "tools_menu_ui_k1c_2025"

--- a/scripts/menu/functions.sh
+++ b/scripts/menu/functions.sh
@@ -211,19 +211,31 @@ function restart_go2rtc() {
 
 function start_klipper() {
   set +e
-  "$INITD_FOLDER"/S55klipper_service start
+  if [ -f "$INITD_FOLDER"/CS55klipper_service ]; then
+    "$INITD_FOLDER"/CS55klipper_service start
+  else
+    "$INITD_FOLDER"/S55klipper_service start
+  fi
   set -e
 }
 
 function stop_klipper() {
   set +e
-  "$INITD_FOLDER"/S55klipper_service stop
+  if [ -f "$INITD_FOLDER"/CS55klipper_service ]; then
+    "$INITD_FOLDER"/CS55klipper_service stop
+  else
+    "$INITD_FOLDER"/S55klipper_service stop
+  fi
   set -e
 }
 
 function restart_klipper() {
   set +e
-  "$INITD_FOLDER"/S55klipper_service restart
+  if [ -f "$INITD_FOLDER"/CS55klipper_service ]; then
+    "$INITD_FOLDER"/CS55klipper_service restart
+  else
+    "$INITD_FOLDER"/S55klipper_service restart
+  fi
   set -e
 }
 

--- a/scripts/moonraker_nginx.sh
+++ b/scripts/moonraker_nginx.sh
@@ -29,6 +29,22 @@ function moonraker_3v3_message(){
   bottom_line
 }
 
+function configure_moonraker_nginx_k1c_2025(){
+  local nginx_conf
+
+  if [ -f "$MOONRAKER_CFG" ]; then
+    echo -e "Info: Setting Moonraker port to 7126..."
+    sed -i 's/^port:[[:space:]]*7125$/port: 7126/' "$MOONRAKER_CFG"
+  fi
+
+  for nginx_conf in "$NGINX_FOLDER"/nginx/nginx.conf /etc/nginx/nginx.conf; do
+    if [ -f "$nginx_conf" ]; then
+      echo -e "Info: Pointing Nginx Moonraker upstream to port 7126 in $nginx_conf..."
+      sed -i 's/server 127\.0\.0\.1:7125;/server 127.0.0.1:7126;/' "$nginx_conf"
+    fi
+  done
+}
+
 function install_moonraker_nginx(){
   moonraker_nginx_message
   local yn
@@ -59,6 +75,9 @@ function install_moonraker_nginx(){
           rm -f "$PRINTER_DATA_FOLDER"/moonraker.asvc
         fi
         cp "$MOONRAKER_URL3" "$PRINTER_DATA_FOLDER"/moonraker.asvc
+        if [ "$model" = "K1C_2025" ]; then
+          configure_moonraker_nginx_k1c_2025
+        fi
         echo -e "Info: Applying changes from official repo..."
         cd "$MOONRAKER_FOLDER"/moonraker
         chown -R root:root .

--- a/scripts/paths.sh
+++ b/scripts/paths.sh
@@ -147,6 +147,7 @@ function set_paths() {
   CAMERA_SETTINGS_FILE="${HS_CONFIG_FOLDER}/camera-settings.cfg"
   CAMERA_SETTINGS_URL="${HS_FILES}/camera-settings/camera-settings.cfg"
   CAMERA_SETTINGS_NEBULA_URL="${HS_FILES}/camera-settings/camera-settings-nebula.cfg"
+  CAMERA_SETTINGS_K1C_2025_URL="${HS_FILES}/camera-settings/camera-settings-k1c-2025.cfg"
   
   # USB Camera Support
   USB_CAMERA_FILE="${INITD_FOLDER}/S50usb_camera"

--- a/scripts/paths.sh
+++ b/scripts/paths.sh
@@ -152,6 +152,9 @@ function set_paths() {
   USB_CAMERA_FILE="${INITD_FOLDER}/S50usb_camera"
   USB_CAMERA_SINGLE_URL="${HS_FILES}/services/S50usb_camera-single"
   USB_CAMERA_DUAL_URL="${HS_FILES}/services/S50usb_camera-dual"
+  USB_CAMERA_K1C_2025_URL="${HS_FILES}/services/S50usb_camera-k1c-2025"
+  BUILTIN_CAMERA_FILE="${INITD_FOLDER}/S50builtin_camera"
+  BUILTIN_CAMERA_K1C_2025_URL="${HS_FILES}/services/S50builtin_camera-k1c-2025"
   
   # OctoEverywhere #
   OCTOEVERYWHERE_FOLDER="${USR_DATA}/octoeverywhere"

--- a/scripts/paths.sh
+++ b/scripts/paths.sh
@@ -65,7 +65,11 @@ function set_paths() {
   KLIPPER_EXTRAS_FOLDER="/usr/share/klipper/klippy/extras"
   KLIPPER_CONFIG_FOLDER="${PRINTER_DATA_FOLDER}/config"
   KLIPPER_KLIPPY_FOLDER="/usr/share/klipper/klippy"
-  KLIPPER_SERVICE_URL="${HS_FILES}/services/S55klipper_service"
+  if [ "$model" = "K1C_2025" ]; then
+    KLIPPER_SERVICE_URL="${HS_FILES}/services/CS55klipper_service_minimal"
+  else
+    KLIPPER_SERVICE_URL="${HS_FILES}/services/S55klipper_service"
+  fi
   KLIPPER_GCODE_URL="${HS_FILES}/fixes/gcode.py"
   KLIPPER_GCODE_3V3_URL="${HS_FILES}/fixes/gcode_3v3.py"
   

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -182,7 +182,14 @@ function enable_camera_settings(){
     case "${yn}" in
       Y|y)
         echo -e "${white}"
-        if grep -q "#\[webcam Camera\]" "$MOONRAKER_CFG" ; then
+        if [ "$model" = "K1C_2025" ]; then
+          if [ -f "$BUILTIN_CAMERA_FILE" ]; then
+            configure_builtin_camera_k1c_2025
+          fi
+          if [ -f "$USB_CAMERA_FILE" ]; then
+            configure_usb_camera_k1c_2025
+          fi
+        elif grep -q "#\[webcam Camera\]" "$MOONRAKER_CFG" ; then
           echo -e "Info: Enabling camera settings in moonraker.conf file..."
           sed -i -e 's/^\s*#[[:space:]]*\[webcam Camera\]/[webcam Camera]/' -e '/^\[webcam Camera\]/,/^\s*$/ s/^\(\s*\)#/\1/' "$MOONRAKER_CFG"
         else
@@ -219,7 +226,15 @@ function disable_camera_settings(){
     case "${yn}" in
       Y|y)
         echo -e "${white}"
-        if grep -q "\[webcam Camera\]" "$MOONRAKER_CFG" ; then
+        if [ "$model" = "K1C_2025" ]; then
+          if grep -q "^\[webcam chassis\]\|^\[webcam usb\]" "$MOONRAKER_CFG"; then
+            echo -e "Info: Disabling camera settings in moonraker.conf file..."
+            sed -i '/^\[webcam chassis\]/,/^$/d' "$MOONRAKER_CFG"
+            sed -i '/^\[webcam usb\]/,/^$/d' "$MOONRAKER_CFG"
+          else
+            echo -e "Info: Camera settings are already disabled in moonraker.conf file..."
+          fi
+        elif grep -q "\[webcam Camera\]" "$MOONRAKER_CFG" ; then
           echo -e "Info: Disabling camera settings in moonraker.conf file..."
           sed -i '/^\[webcam Camera\]/,/^\s*$/ s/^\(\s*\)\([^#]\)/#\1\2/' "$MOONRAKER_CFG"
         else

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -90,6 +90,23 @@ function reset_factory_settings_message(){
   bottom_line
 }
 
+# Basename of the active Klipper init script (S55… or CS55… on newer K1C firmware), or empty.
+klipper_init_script_basename() {
+  if [ -f "$INITD_FOLDER/S55klipper_service" ]; then
+    echo S55klipper_service
+  elif [ -f "$INITD_FOLDER/CS55klipper_service" ]; then
+    echo CS55klipper_service
+  fi
+}
+
+klipper_disabled_backup_basename() {
+  if [ -f "$INITD_FOLDER/disabled.S55klipper_service" ]; then
+    echo disabled.S55klipper_service
+  elif [ -f "$INITD_FOLDER/disabled.CS55klipper_service" ]; then
+    echo disabled.CS55klipper_service
+  fi
+}
+
 function prevent_updating_klipper_files(){
   prevent_updating_klipper_files_message
   local yn
@@ -98,12 +115,17 @@ function prevent_updating_klipper_files(){
     case "${yn}" in
       Y|y)
         echo -e "${white}"
+        klipper_init="$(klipper_init_script_basename)"
+        if [ -z "$klipper_init" ]; then
+          error_msg "Klipper init script not found in ${INITD_FOLDER} (expected S55klipper_service or CS55klipper_service)."
+          return
+        fi
         echo -e "Info: Backup file..."
-        mv "$INITD_FOLDER"/S55klipper_service "$INITD_FOLDER"/disabled.S55klipper_service
+        mv "$INITD_FOLDER/$klipper_init" "$INITD_FOLDER/disabled.$klipper_init"
         echo -e "Info: Copying file..."
-        cp "$KLIPPER_SERVICE_URL" "$INITD_FOLDER"/S55klipper_service
+        cp "$KLIPPER_SERVICE_URL" "$INITD_FOLDER/$klipper_init"
         echo -e "Info: Applying permissions..."
-        chmod 755 "$INITD_FOLDER"/S55klipper_service
+        chmod 755 "$INITD_FOLDER/$klipper_init"
         echo -e "Info: Restarting Klipper service..."
         restart_klipper
         ok_msg "Klipper configuration files will no longer be updated when Klipper restarts!"
@@ -125,9 +147,15 @@ function allow_updating_klipper_files(){
     case "${yn}" in
       Y|y)
         echo -e "${white}"
+        disabled_backup="$(klipper_disabled_backup_basename)"
+        if [ -z "$disabled_backup" ]; then
+          error_msg "No disabled Klipper init backup found in ${INITD_FOLDER}."
+          return
+        fi
+        klipper_init="${disabled_backup#disabled.}"
         echo -e "Info: Restoring file..."
-        rm -f "$INITD_FOLDER"/S55klipper_service
-        mv "$INITD_FOLDER"/disabled.S55klipper_service "$INITD_FOLDER"/S55klipper_service
+        rm -f "$INITD_FOLDER/$klipper_init"
+        mv "$INITD_FOLDER/$disabled_backup" "$INITD_FOLDER/$klipper_init"
         echo -e "Info: Restarting Klipper service..."
         restart_klipper
         ok_msg "Klipper configuration files will be updated when Klipper restarts!"

--- a/scripts/usb_camera.sh
+++ b/scripts/usb_camera.sh
@@ -13,6 +13,70 @@ function usb_camera_message(){
   bottom_line
 }
 
+function builtin_camera_message(){
+  top_line
+  title 'Built-in Camera Fix' "${yellow}"
+  inner_line
+  hr
+  echo -e " в”‚ ${cyan}This allows to use the K1C 2025 built-in camera with        ${white}в”‚"
+  echo -e " в”‚ ${cyan}Fluidd and Mainsail through mjpg-streamer.                  ${white}в”‚"
+  hr
+  bottom_line
+}
+
+function configure_usb_camera_k1c_2025(){
+  local usb_dev
+
+  if [ ! -f "$MOONRAKER_CFG" ]; then
+    return
+  fi
+
+  usb_dev=$(v4l2-ctl --list-devices | grep -A1 usb | sed 's/^[[:space:]]*//g' | grep '^/dev' | grep -v '^/dev/video0$' | head -n 1)
+  if [ -n "$usb_dev" ]; then
+    echo -e "Info: Configuring USB camera in moonraker.conf..."
+    sed -i '/^\[webcam usb\]/,/^$/d' "$MOONRAKER_CFG"
+    cat >> "$MOONRAKER_CFG" <<EOF
+
+[webcam usb]
+enabled: True
+location: printer
+service: mjpegstreamer
+target_fps: 15
+target_fps_idle: 5
+stream_url: /webcam2/?action=stream
+snapshot_url: /webcam2/?action=snapshot
+flip_horizontal: False
+flip_vertical: False
+rotation: 0
+aspect_ratio: 16:9
+EOF
+  fi
+}
+
+function configure_builtin_camera_k1c_2025(){
+  if [ ! -f "$MOONRAKER_CFG" ]; then
+    return
+  fi
+
+  echo -e "Info: Configuring built-in camera in moonraker.conf..."
+  sed -i '/^\[webcam chassis\]/,/^$/d' "$MOONRAKER_CFG"
+  cat >> "$MOONRAKER_CFG" <<EOF
+
+[webcam chassis]
+enabled: True
+location: printer
+service: mjpegstreamer
+target_fps: 15
+target_fps_idle: 5
+stream_url: /webcam/?action=stream
+snapshot_url: /webcam/?action=snapshot
+flip_horizontal: False
+flip_vertical: False
+rotation: 0
+aspect_ratio: 16:9
+EOF
+}
+
 function install_usb_camera(){
   usb_camera_message
   local yn
@@ -22,7 +86,9 @@ function install_usb_camera(){
       Y|y)
         echo -e "${white}"
         echo -e "Info: Copying file..."
-        if [ "$model" = "K1" ]; then
+        if [ "$model" = "K1C_2025" ]; then
+          cp "$USB_CAMERA_K1C_2025_URL" "$INITD_FOLDER"/S50usb_camera
+        elif [ "$model" = "K1" ]; then
           cp "$USB_CAMERA_DUAL_URL" "$INITD_FOLDER"/S50usb_camera
         else
           cp "$USB_CAMERA_SINGLE_URL" "$INITD_FOLDER"/S50usb_camera
@@ -60,10 +126,89 @@ function install_usb_camera(){
         "$ENTWARE_FILE" update && "$ENTWARE_FILE" install mjpg-streamer mjpg-streamer-input-http mjpg-streamer-input-uvc mjpg-streamer-output-http mjpg-streamer-www
         echo -e "Info: Starting service..."
         "$INITD_FOLDER"/S50usb_camera start
+        if [ "$model" = "K1C_2025" ]; then
+          configure_usb_camera_k1c_2025
+          if [ -f "$INITD_FOLDER"/S56moonraker_service ]; then
+            stop_moonraker
+            start_moonraker
+          fi
+        fi
         ok_msg "USB Camera Support has been installed successfully!"
         return;;
       N|n)
         error_msg "Installation canceled!"
+        return;;
+      *)
+        error_msg "Please select a correct choice!";;
+    esac
+  done
+}
+
+function install_builtin_camera(){
+  builtin_camera_message
+  local yn
+  while true; do
+    install_msg "Built-in Camera Fix" yn
+    case "${yn}" in
+      Y|y)
+        echo -e "${white}"
+        echo -e "Info: Copying file..."
+        cp "$BUILTIN_CAMERA_K1C_2025_URL" "$BUILTIN_CAMERA_FILE"
+        chmod 755 "$BUILTIN_CAMERA_FILE"
+        echo -e "Info: Installing necessary packages..."
+        "$ENTWARE_FILE" update && "$ENTWARE_FILE" install mjpg-streamer mjpg-streamer-input-http mjpg-streamer-input-uvc mjpg-streamer-output-http mjpg-streamer-www
+        echo -e "Info: Starting service..."
+        "$BUILTIN_CAMERA_FILE" start
+        configure_builtin_camera_k1c_2025
+        if [ -f "$INITD_FOLDER"/S56moonraker_service ]; then
+          stop_moonraker
+          start_moonraker
+        fi
+        ok_msg "Built-in Camera Fix has been installed successfully!"
+        return;;
+      N|n)
+        error_msg "Installation canceled!"
+        return;;
+      *)
+        error_msg "Please select a correct choice!";;
+    esac
+  done
+}
+
+function remove_builtin_camera(){
+  builtin_camera_message
+  local yn
+  while true; do
+    remove_msg "Built-in Camera Fix" yn
+    case "${yn}" in
+      Y|y)
+        echo -e "${white}"
+        echo -e "Info: Stopping service..."
+        "$BUILTIN_CAMERA_FILE" stop
+        echo -e "Info: Removing file..."
+        rm -f "$BUILTIN_CAMERA_FILE"
+        if [ -f "$MOONRAKER_CFG" ]; then
+          echo -e "Info: Removing built-in camera configuration in moonraker.conf file..."
+          sed -i '/^\[webcam chassis\]/,/^$/d' "$MOONRAKER_CFG"
+          if [ -f "$INITD_FOLDER"/S56moonraker_service ]; then
+            stop_moonraker
+            start_moonraker
+          fi
+        fi
+        echo -e "Info: Removing packages..."
+        set +e
+        if [ ! -f "$USB_CAMERA_FILE" ]; then
+          "$ENTWARE_FILE" --autoremove remove mjpg-streamer-www
+          "$ENTWARE_FILE" --autoremove remove mjpg-streamer-output-http
+          "$ENTWARE_FILE" --autoremove remove mjpg-streamer-input-uvc
+          "$ENTWARE_FILE" --autoremove remove mjpg-streamer-input-http
+          "$ENTWARE_FILE" --autoremove remove mjpg-streamer
+        fi
+        set -e
+        ok_msg "Built-in Camera Fix has been removed successfully!"
+        return;;
+      N|n)
+        error_msg "Deletion canceled!"
         return;;
       *)
         error_msg "Please select a correct choice!";;
@@ -83,13 +228,23 @@ function remove_usb_camera(){
         "$INITD_FOLDER"/S50usb_camera stop
         echo -e "Info: Removing file..."
         rm -f "$INITD_FOLDER"/S50usb_camera
+        if [ "$model" = "K1C_2025" ] && [ -f "$MOONRAKER_CFG" ]; then
+          echo -e "Info: Removing USB Camera configurations in moonraker.conf file..."
+          sed -i '/^\[webcam usb\]/,/^$/d' "$MOONRAKER_CFG"
+          if [ -f "$INITD_FOLDER"/S56moonraker_service ]; then
+            stop_moonraker
+            start_moonraker
+          fi
+        fi
         echo -e "Info: Removing packages..."
         set +e
-        "$ENTWARE_FILE" --autoremove remove mjpg-streamer-www
-        "$ENTWARE_FILE" --autoremove remove mjpg-streamer-output-http
-        "$ENTWARE_FILE" --autoremove remove mjpg-streamer-input-uvc
-        "$ENTWARE_FILE" --autoremove remove mjpg-streamer-input-http
-        "$ENTWARE_FILE" --autoremove remove mjpg-streamer
+        if [ "$model" != "K1C_2025" ] || [ ! -f "$BUILTIN_CAMERA_FILE" ]; then
+          "$ENTWARE_FILE" --autoremove remove mjpg-streamer-www
+          "$ENTWARE_FILE" --autoremove remove mjpg-streamer-output-http
+          "$ENTWARE_FILE" --autoremove remove mjpg-streamer-input-uvc
+          "$ENTWARE_FILE" --autoremove remove mjpg-streamer-input-http
+          "$ENTWARE_FILE" --autoremove remove mjpg-streamer
+        fi
         set -e
         ok_msg "USB Camera Support has been removed successfully!"
         echo -e "   Please reboot your printer by using power switch on back!"

--- a/scripts/usb_camera.sh
+++ b/scripts/usb_camera.sh
@@ -77,6 +77,23 @@ aspect_ratio: 16:9
 EOF
 }
 
+function ensure_mjpg_streamer_packages(){
+  if "$ENTWARE_FILE" list | grep -q '^mjpg-streamer '; then
+    return
+  fi
+
+  if [ "$model" = "K1C_2025" ]; then
+    echo -e "Info: Updating Entware repository for mjpg-streamer packages..."
+    sed -i '1s|.*|src/gz entware http://bin.tranducanh.com/mipselsf-k3.4|' /opt/etc/opkg.conf
+    "$ENTWARE_FILE" update
+  fi
+
+  if ! "$ENTWARE_FILE" list | grep -q '^mjpg-streamer '; then
+    error_msg "mjpg-streamer packages are not available in the configured Entware repository!"
+    return 1
+  fi
+}
+
 function install_usb_camera(){
   usb_camera_message
   local yn
@@ -123,6 +140,7 @@ function install_usb_camera(){
         fi
         chmod 755 "$INITD_FOLDER"/S50usb_camera
         echo -e "Info: Installing necessary packages..."
+        ensure_mjpg_streamer_packages
         "$ENTWARE_FILE" update && "$ENTWARE_FILE" install mjpg-streamer mjpg-streamer-input-http mjpg-streamer-input-uvc mjpg-streamer-output-http mjpg-streamer-www
         echo -e "Info: Starting service..."
         "$INITD_FOLDER"/S50usb_camera start
@@ -156,6 +174,7 @@ function install_builtin_camera(){
         cp "$BUILTIN_CAMERA_K1C_2025_URL" "$BUILTIN_CAMERA_FILE"
         chmod 755 "$BUILTIN_CAMERA_FILE"
         echo -e "Info: Installing necessary packages..."
+        ensure_mjpg_streamer_packages
         "$ENTWARE_FILE" update && "$ENTWARE_FILE" install mjpg-streamer mjpg-streamer-input-http mjpg-streamer-input-uvc mjpg-streamer-output-http mjpg-streamer-www
         echo -e "Info: Starting service..."
         "$BUILTIN_CAMERA_FILE" start

--- a/scripts/usb_camera.sh
+++ b/scripts/usb_camera.sh
@@ -43,8 +43,8 @@ location: printer
 service: mjpegstreamer
 target_fps: 15
 target_fps_idle: 5
-stream_url: /webcam2/?action=stream
-snapshot_url: /webcam2/?action=snapshot
+stream_url: /webcam3/?action=stream
+snapshot_url: /webcam3/?action=snapshot
 flip_horizontal: False
 flip_vertical: False
 rotation: 0

--- a/scripts/usb_camera.sh
+++ b/scripts/usb_camera.sh
@@ -184,7 +184,9 @@ function remove_builtin_camera(){
       Y|y)
         echo -e "${white}"
         echo -e "Info: Stopping service..."
+        set +e
         "$BUILTIN_CAMERA_FILE" stop
+        set -e
         echo -e "Info: Removing file..."
         rm -f "$BUILTIN_CAMERA_FILE"
         if [ -f "$MOONRAKER_CFG" ]; then
@@ -225,7 +227,9 @@ function remove_usb_camera(){
       Y|y)
         echo -e "${white}"
         echo -e "Info: Stopping service..."
+        set +e
         "$INITD_FOLDER"/S50usb_camera stop
+        set -e
         echo -e "Info: Removing file..."
         rm -f "$INITD_FOLDER"/S50usb_camera
         if [ "$model" = "K1C_2025" ] && [ -f "$MOONRAKER_CFG" ]; then


### PR DESCRIPTION
## Summary

Fix K1C 2025 Moonraker/nginx and go2rtc camera setup.

## Changes

- Configure K1C 2025 Moonraker to run on port `7126`.
- Point nginx Moonraker upstream from `127.0.0.1:7125` to `127.0.0.1:7126`.
- Add K1C 2025 go2rtc webcam registration to `moonraker.conf`.
- Add nginx `/go2rtc/` proxy to `127.0.0.1:1984`.
- Use relative webcam URLs so Fluidd/Mainsail do not depend on the printer IP:
  - `/go2rtc/api/stream.mp4?src=chassis`
  - `/go2rtc/api/frame.jpeg?src=chassis`
- Keep Moonraker/nginx setup separate from camera setup:
  - Moonraker/nginx handles port `7126` and upstream routing.
  - go2rtc handles camera config and camera proxying.