### PR TITLE
Drop UNTESTED flag from K1C 2025 gcode shell command

### DIFF
--- a/scripts/gcode_shell_command.sh
+++ b/scripts/gcode_shell_command.sh
@@ -26,6 +26,9 @@ function install_gcode_shell_command(){
         ln -sf "$KLIPPER_SHELL_URL" "$KLIPPER_EXTRAS_FOLDER"/gcode_shell_command.py
         echo -e "Info: Restarting Klipper service..."
         restart_klipper
+        # Verify with the Klipper API method "gcode/help" (RUN_SHELL_COMMAND will be
+        # listed) — Creality's Klipper does NOT surface gcode_shell_command via
+        # "objects/list", so the extra can look like it failed to load when it works.
         ok_msg "Klipper Gcode Shell Command has been installed successfully!"
         return;;
       N|n)

--- a/scripts/menu/K1_2025/install_menu_K1C_2025.sh
+++ b/scripts/menu/K1_2025/install_menu_K1C_2025.sh
@@ -14,7 +14,7 @@ function install_menu_ui_k1_2025() {
   hr
   subtitle '•UTILITIES:'
   menu_option ' 4' 'Install' 'Entware'
-  menu_option ' 5' 'Install' 'Klipper Gcode Shell Command !!!UNTESTED!!!'
+  menu_option ' 5' 'Install' 'Klipper Gcode Shell Command'
   hr
   subtitle '•CAMERA:'
   menu_option ' 6' 'Install' 'Go2rtc'


### PR DESCRIPTION
The K1C 2025 install menu flags "Klipper Gcode Shell Command" as `!!!UNTESTED!!!`. It actually works — the flag most likely survives because Creality's Klipper hides the extra from `objects/list`, the usual place to check, so it looks like it never loaded.

Verified on `K1C-2025_V1.0.0.22.20250711S`: the existing `ln -sf` install registers `RUN_SHELL_COMMAND` and runs shell commands end to end (five `[gcode_shell_command …]` sections driving resource logging and ntfy notifications in daily use here). The authoritative check is the `gcode/help` API method, which lists `RUN_SHELL_COMMAND`; `objects/list` does not surface `gcode_shell_command` objects on Creality Klipper. This drops the flag and adds a one-line note pointing at the right verification method.

Evidence (klippy UDS query on that firmware):
- `gcode/help` → `RUN_SHELL_COMMAND present: True`
- `objects/list` → no `gcode_shell_command` objects

## Test plan
- [x] `sh -n` parses both edited scripts
- [x] `gcode/help` lists `RUN_SHELL_COMMAND` after the menu's `ln -sf` install
- [x] `RUN_SHELL_COMMAND` executes shell commands end to end (resource-log archives written, ntfy pushes sent)
