### PR TITLE
Point helper-script update_manager at this fork

### DIFF
--- a/files/moonraker/moonraker.conf
+++ b/files/moonraker/moonraker.conf
@@ -52,7 +52,7 @@ enable_system_updates: False
 type: git_repo
 channel: dev
 path: /usr/data/helper-script
-origin: https://github.com/Guilouz/Creality-Helper-Script.git
+origin: https://github.com/C0DEbrained/Creality-Helper-Script-2025.git
 primary_branch: main
 managed_services: klipper
 


### PR DESCRIPTION
On a K1 2025 install, Moonraker's `update_manager` for the helper script tracks the wrong repo: the bundled `files/moonraker/moonraker.conf` still carries upstream guilouz's `origin`, so `[update_manager Creality-Helper-Script]` points at `Guilouz/Creality-Helper-Script` instead of this fork. If it ever pulled, it would try to apply upstream's code over a fork install.

This repoints `origin` to `C0DEbrained/Creality-Helper-Script-2025`. `path` is left at the documented `/usr/data/helper-script` convention — verified working on a K1C-2025 (`is_valid: true`, `repo_detected: true`, tracking the fork on `main`) once `origin` matches the clone.

## Test plan
- [x] update_manager reports `is_valid: true` / `repo_detected: true` against the corrected origin on K1C-2025_V1.0.0.22
- [x] Moonraker startup log clean — no "Failed to load extension Creality-Helper-Script" / "Invalid path" warnings
