### PR TITLE
Enable Moonraker Timelapse for K1C 2025

### DIFF
--- a/scripts/menu/K1_2025/install_menu_K1C_2025.sh
+++ b/scripts/menu/K1_2025/install_menu_K1C_2025.sh
@@ -21,6 +21,7 @@ function install_menu_ui_k1_2025() {
   menu_option ' 7' 'Install' 'USB Camera Support'
   menu_option ' 8' 'Install' 'Built-in Camera Fix'
   menu_option ' 9' 'Install' 'Camera Settings Control'
+  menu_option '10' 'Install' 'Moonraker Timelapse'
 #  hr
 #  subtitle '•IMPROVEMENTS:'
 #  disabled_menu_option ' 6' 'Install' 'Klipper Adaptive Meshing & Purging'
@@ -142,6 +143,16 @@ function install_menu_k1_2025() {
           error_msg "Klipper Gcode Shell Command is needed, please install it first!"
         else
           run "install_camera_settings_control" "install_menu_ui_k1_2025"
+        fi;;
+      10)
+        if [ -f "$TIMELAPSE_FILE" ]; then
+          error_msg "Moonraker Timelapse is already installed!"
+        elif [ ! -f "$ENTWARE_FILE" ]; then
+          error_msg "Entware is needed, please install it first!"
+        elif [ ! -d "$MOONRAKER_FOLDER" ] || [ ! -d "$NGINX_FOLDER" ]; then
+          error_msg "Moonraker and Nginx are needed, please install them first!"
+        else
+          run "install_moonraker_timelapse" "install_menu_ui_k1_2025"
         fi;;
 #      7)
 #        disabled_feature;;

--- a/scripts/menu/K1_2025/remove_menu_K1C_2025.sh
+++ b/scripts/menu/K1_2025/remove_menu_K1C_2025.sh
@@ -21,6 +21,7 @@ function remove_menu_ui_k1_2025() {
   menu_option ' 7' 'Remove' 'USB Camera Support'
   menu_option ' 8' 'Remove' 'Built-in Camera Fix'
   menu_option ' 9' 'Remove' 'Camera Settings Control'
+  menu_option '10' 'Remove' 'Moonraker Timelapse'
 #  hr
 #  subtitle '•IMPROVEMENTS:'
 #  disabled_menu_option ' 6' 'Remove' 'Klipper Adaptive Meshing & Purging'
@@ -151,6 +152,12 @@ function remove_menu_k1_2025() {
           error_msg "Camera Settings Control is not installed!"
         else
           run "remove_camera_settings_control" "remove_menu_ui_k1_2025"
+        fi;;
+      10)
+        if [ ! -f "$TIMELAPSE_FILE" ]; then
+          error_msg "Moonraker Timelapse is not installed!"
+        else
+          run "remove_moonraker_timelapse" "remove_menu_ui_k1_2025"
         fi;;
 
 #      6)

--- a/scripts/moonraker_timelapse.sh
+++ b/scripts/moonraker_timelapse.sh
@@ -29,12 +29,27 @@ function install_moonraker_timelapse(){
         fi
         echo -e "Info: Linking file..."
         ln -sf "$TIMELAPSE_URL1" "$TIMELAPSE_FILE"
-        ln -sf "$TIMELAPSE_URL2" "$HS_CONFIG_FOLDER"/timelapse.cfg
+        if [ "$model" = "K1_2025" ]; then
+          # K1_2025 runs Klipper as the unprivileged 'creality' user, which cannot read a
+          # symlink whose target is in the root-owned helper-script tree (Klipper then reports
+          # "Include file does not exist"). Use a real copy, and make the config dir
+          # traversable (mkdir under root's umask creates it mode 700).
+          chmod 755 "$HS_CONFIG_FOLDER"
+          cp -f "$TIMELAPSE_URL2" "$HS_CONFIG_FOLDER"/timelapse.cfg
+          chmod 644 "$HS_CONFIG_FOLDER"/timelapse.cfg
+        else
+          ln -sf "$TIMELAPSE_URL2" "$HS_CONFIG_FOLDER"/timelapse.cfg
+        fi
         if grep -q "include Helper-Script/timelapse" "$PRINTER_CFG" ; then
           echo -e "Info: Moonraker Timelapse configurations are already enabled in printer.cfg file..."
-        else
+        elif grep -q "\[include printer_params\.cfg\]" "$PRINTER_CFG" ; then
           echo -e "Info: Adding Moonraker Timelapse configurations in printer.cfg file..."
           sed -i '/\[include printer_params\.cfg\]/a \[include Helper-Script/timelapse\.cfg\]' "$PRINTER_CFG"
+        else
+          # K1_2025 ships a monolithic printer.cfg without the printer_params anchor;
+          # prepend the include (owner-preserving rewrite so Klipper SAVE_CONFIG keeps working).
+          echo -e "Info: Adding Moonraker Timelapse configurations in printer.cfg file..."
+          { echo "[include Helper-Script/timelapse.cfg]"; cat "$PRINTER_CFG"; } > "$PRINTER_CFG.hs_tmp" && cat "$PRINTER_CFG.hs_tmp" > "$PRINTER_CFG" && rm -f "$PRINTER_CFG.hs_tmp"
         fi
         if grep -q "#\[timelapse\]" "$MOONRAKER_CFG" ; then
           echo -e "Info: Enabling Moonraker Timelapse configurations in moonraker.conf file..."
@@ -44,6 +59,19 @@ function install_moonraker_timelapse(){
         fi
         echo -e "Info: Updating ffmpeg..."
         "$ENTWARE_FILE" update && "$ENTWARE_FILE" upgrade ffmpeg
+        if [ "$model" = "K1_2025" ]; then
+          # The timelapse component is loaded by Moonraker at startup, so Moonraker must be
+          # restarted (not just Klipper) for it to register. S56moonraker_service has no
+          # 'restart' verb, so stop + start. Run it in a subshell with umask 022: the
+          # Creality root shell defaults to umask 077, and a Moonraker started that way writes
+          # g-code uploads mode 600 — unreadable by the unprivileged 'creality' Klipper user,
+          # so prints fail with XD5027 "Unable to open file".
+          echo -e "Info: Restarting Moonraker service..."
+          ( umask 022
+            "$INITD_FOLDER"/S56moonraker_service stop 2>/dev/null
+            sleep 1
+            "$INITD_FOLDER"/S56moonraker_service start 2>/dev/null ) || true
+        fi
         echo -e "Info: Restarting Klipper service..."
         restart_klipper
         ok_msg "Moonraker Timelapse has been installed successfully!"


### PR DESCRIPTION
The K1C 2025 menu ships Moonraker Timelapse disabled — the generic installer breaks on this model, so it was never wired into the active menu. This enables it with a 2025-aware install path.

Four things differ on the 2025 versus models where timelapse already works:

- Klipper runs as the unprivileged `creality` user (root elsewhere), so it can't read a symlinked `timelapse.cfg` whose target is in the root-owned helper-script tree — Klipper rejects the config with "Include file does not exist". The 2025 path copies the file and makes the `Helper-Script` dir traversable (mkdir under root's umask leaves it mode 700).
- The 2025's `printer.cfg` is monolithic with no `[include printer_params.cfg]` anchor, so the existing `sed` insert silently no-ops. The include now uses that anchor when present and prepends otherwise.
- The timelapse component is loaded by Moonraker, not Klipper, so the 2025 path restarts Moonraker (`S56moonraker_service` has no `restart` verb → stop+start) in addition to Klipper.
- That Moonraker restart runs under `umask 022`: the Creality root shell defaults to umask 077, and a Moonraker started that way writes g-code uploads mode 600 — unreadable by the `creality` Klipper user, so prints then fail with XD5027 "Unable to open file".

Every new branch is guarded by `model = K1_2025`; all other models keep their existing symlink + anchor behavior.

## Test plan
- [x] `sh -n` clean on all three modified scripts
- [x] Each install operation verified by hand on a K1C 2025 (FW V1.0.0.22): cfg copy + perms, include prepend, `[timelapse]` enable, entware ffmpeg 5.1.3, Moonraker+Klipper restart → `klippy_state: ready`, all six timelapse macros registered, component responds on `/machine/timelapse/lastframeinfo`
- [x] Verified the umask trap on hardware: a umask-077 Moonraker restart writes mode-600 uploads → XD5027; the umask-022 path restores 644 uploads that klippy reads
- [ ] Full install **and** remove run through the helper TUI (option 10) — not yet click-tested; menu wiring mirrors the existing enabled options

## Manual test pass
- [ ] Install → 10 on a K1C 2025, confirm a print captures + renders a timelapse
- [ ] Remove → 10, confirm the include + `[timelapse]` are removed and Klipper still boots
