### PR TITLE
Add Restore Input Shapers for K1C 2025

### DIFF
--- a/files/restore-input-shapers/shaper_defs.py
+++ b/files/restore-input-shapers/shaper_defs.py
@@ -1,0 +1,102 @@
+# Definitions of the supported input shapers
+#
+# Copyright (C) 2020-2021  Dmitry Butyugin <dmbutyugin@google.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import collections, math
+
+SHAPER_VIBRATION_REDUCTION=20.
+DEFAULT_DAMPING_RATIO = 0.1
+
+InputShaperCfg = collections.namedtuple(
+        'InputShaperCfg', ('name', 'init_func', 'min_freq'))
+
+def get_none_shaper():
+    return ([], [])
+
+def get_zv_shaper(shaper_freq, damping_ratio):
+    df = math.sqrt(1. - damping_ratio**2)
+    K = math.exp(-damping_ratio * math.pi / df)
+    t_d = 1. / (shaper_freq * df)
+    A = [1., K]
+    T = [0., .5*t_d]
+    return (A, T)
+
+def get_zvd_shaper(shaper_freq, damping_ratio):
+    df = math.sqrt(1. - damping_ratio**2)
+    K = math.exp(-damping_ratio * math.pi / df)
+    t_d = 1. / (shaper_freq * df)
+    A = [1., 2.*K, K**2]
+    T = [0., .5*t_d, t_d]
+    return (A, T)
+
+def get_mzv_shaper(shaper_freq, damping_ratio):
+    df = math.sqrt(1. - damping_ratio**2)
+    K = math.exp(-.75 * damping_ratio * math.pi / df)
+    t_d = 1. / (shaper_freq * df)
+
+    a1 = 1. - 1. / math.sqrt(2.)
+    a2 = (math.sqrt(2.) - 1.) * K
+    a3 = a1 * K * K
+
+    A = [a1, a2, a3]
+    T = [0., .375*t_d, .75*t_d]
+    return (A, T)
+
+def get_ei_shaper(shaper_freq, damping_ratio):
+    v_tol = 1. / SHAPER_VIBRATION_REDUCTION # vibration tolerance
+    df = math.sqrt(1. - damping_ratio**2)
+    K = math.exp(-damping_ratio * math.pi / df)
+    t_d = 1. / (shaper_freq * df)
+
+    a1 = .25 * (1. + v_tol)
+    a2 = .5 * (1. - v_tol) * K
+    a3 = a1 * K * K
+
+    A = [a1, a2, a3]
+    T = [0., .5*t_d, t_d]
+    return (A, T)
+
+def get_2hump_ei_shaper(shaper_freq, damping_ratio):
+    v_tol = 1. / SHAPER_VIBRATION_REDUCTION # vibration tolerance
+    df = math.sqrt(1. - damping_ratio**2)
+    K = math.exp(-damping_ratio * math.pi / df)
+    t_d = 1. / (shaper_freq * df)
+
+    V2 = v_tol**2
+    X = pow(V2 * (math.sqrt(1. - V2) + 1.), 1./3.)
+    a1 = (3.*X*X + 2.*X + 3.*V2) / (16.*X)
+    a2 = (.5 - a1) * K
+    a3 = a2 * K
+    a4 = a1 * K * K * K
+
+    A = [a1, a2, a3, a4]
+    T = [0., .5*t_d, t_d, 1.5*t_d]
+    return (A, T)
+
+def get_3hump_ei_shaper(shaper_freq, damping_ratio):
+    v_tol = 1. / SHAPER_VIBRATION_REDUCTION # vibration tolerance
+    df = math.sqrt(1. - damping_ratio**2)
+    K = math.exp(-damping_ratio * math.pi / df)
+    t_d = 1. / (shaper_freq * df)
+
+    K2 = K*K
+    a1 = 0.0625 * (1. + 3. * v_tol + 2. * math.sqrt(2. * (v_tol + 1.) * v_tol))
+    a2 = 0.25 * (1. - v_tol) * K
+    a3 = (0.5 * (1. + v_tol) - 2. * a1) * K2
+    a4 = a2 * K2
+    a5 = a1 * K2 * K2
+
+    A = [a1, a2, a3, a4, a5]
+    T = [0., .5*t_d, t_d, 1.5*t_d, 2.*t_d]
+    return (A, T)
+
+# min_freq for each shaper is chosen to have projected max_accel ~= 1500
+INPUT_SHAPERS = [
+    InputShaperCfg('zv', get_zv_shaper, min_freq=21.),
+    InputShaperCfg('mzv', get_mzv_shaper, min_freq=23.),
+    InputShaperCfg('zvd', get_zvd_shaper, min_freq=29.),
+    InputShaperCfg('ei', get_ei_shaper, min_freq=29.),
+    InputShaperCfg('2hump_ei', get_2hump_ei_shaper, min_freq=39.),
+    InputShaperCfg('3hump_ei', get_3hump_ei_shaper, min_freq=48.),
+]

--- a/scripts/menu/K1_2025/info_menu_K1C_2025.sh
+++ b/scripts/menu/K1_2025/info_menu_K1C_2025.sh
@@ -61,6 +61,7 @@ function info_menu_ui_k1_2025() {
   info_line "$(check_folder_k1_2025 "$NOZZLE_CLEANING_FOLDER")" 'Nozzle Cleaning Fan Control'
   info_line "$(check_file_k1_2025 "$FAN_CONTROLS_FILE")" 'Fans Control Macros'
   info_line "$(check_folder_k1_2025 "$IMP_SHAPERS_FOLDER")" 'Improved Shapers Calibrations'
+  info_line "$(check_file_k1_2025 "$SHAPER_DEFS_FILE")" 'Restore Input Shapers'
   info_line "$(check_file_k1_2025 "$USEFUL_MACROS_FILE")" 'Useful Macros'
   info_line "$(check_file_k1_2025 "$SAVE_ZOFFSET_FILE")" 'Save Z-Offset Macros'
   info_line "$(check_file_k1_2025 "$SCREWS_ADJUST_FILE")" 'Screws Tilt Adjust Support'

--- a/scripts/menu/K1_2025/install_menu_K1C_2025.sh
+++ b/scripts/menu/K1_2025/install_menu_K1C_2025.sh
@@ -21,6 +21,7 @@ function install_menu_ui_k1_2025() {
   menu_option ' 7' 'Install' 'USB Camera Support'
   menu_option ' 8' 'Install' 'Built-in Camera Fix'
   menu_option ' 9' 'Install' 'Camera Settings Control'
+  menu_option '10' 'Install' 'Moonraker Timelapse'
 #  hr
 #  subtitle '•IMPROVEMENTS:'
 #  disabled_menu_option ' 6' 'Install' 'Klipper Adaptive Meshing & Purging'
@@ -142,6 +143,16 @@ function install_menu_k1_2025() {
           error_msg "Klipper Gcode Shell Command is needed, please install it first!"
         else
           run "install_camera_settings_control" "install_menu_ui_k1_2025"
+        fi;;
+      10)
+        if [ -f "$TIMELAPSE_FILE" ]; then
+          error_msg "Moonraker Timelapse is already installed!"
+        elif [ ! -f "$ENTWARE_FILE" ]; then
+          error_msg "Entware is needed, please install it first!"
+        elif [ ! -d "$MOONRAKER_FOLDER" ] || [ ! -d "$NGINX_FOLDER" ]; then
+          error_msg "Moonraker and Nginx are needed, please install them first!"
+        else
+          run "install_moonraker_timelapse" "install_menu_ui_k1_2025"
         fi;;
 #      7)
 #        disabled_feature;;

--- a/scripts/menu/K1_2025/install_menu_K1C_2025.sh
+++ b/scripts/menu/K1_2025/install_menu_K1C_2025.sh
@@ -22,6 +22,9 @@ function install_menu_ui_k1_2025() {
   menu_option ' 8' 'Install' 'Built-in Camera Fix'
   menu_option ' 9' 'Install' 'Camera Settings Control'
   menu_option '10' 'Install' 'Moonraker Timelapse'
+  hr
+  subtitle '•IMPROVEMENTS:'
+  menu_option '11' 'Install' 'Restore Input Shapers'
 #  hr
 #  subtitle '•IMPROVEMENTS:'
 #  disabled_menu_option ' 6' 'Install' 'Klipper Adaptive Meshing & Purging'
@@ -153,6 +156,12 @@ function install_menu_k1_2025() {
           error_msg "Moonraker and Nginx are needed, please install them first!"
         else
           run "install_moonraker_timelapse" "install_menu_ui_k1_2025"
+        fi;;
+      11)
+        if [ -f "$SHAPER_DEFS_FILE" ]; then
+          error_msg "Restore Input Shapers is already installed!"
+        else
+          run "install_restore_input_shapers" "install_menu_ui_k1_2025"
         fi;;
 #      7)
 #        disabled_feature;;

--- a/scripts/menu/K1_2025/remove_menu_K1C_2025.sh
+++ b/scripts/menu/K1_2025/remove_menu_K1C_2025.sh
@@ -22,6 +22,9 @@ function remove_menu_ui_k1_2025() {
   menu_option ' 8' 'Remove' 'Built-in Camera Fix'
   menu_option ' 9' 'Remove' 'Camera Settings Control'
   menu_option '10' 'Remove' 'Moonraker Timelapse'
+  hr
+  subtitle '•IMPROVEMENTS:'
+  menu_option '11' 'Remove' 'Restore Input Shapers'
 #  hr
 #  subtitle '•IMPROVEMENTS:'
 #  disabled_menu_option ' 6' 'Remove' 'Klipper Adaptive Meshing & Purging'
@@ -158,6 +161,12 @@ function remove_menu_k1_2025() {
           error_msg "Moonraker Timelapse is not installed!"
         else
           run "remove_moonraker_timelapse" "remove_menu_ui_k1_2025"
+        fi;;
+      11)
+        if [ ! -f "$SHAPER_DEFS_FILE" ]; then
+          error_msg "Restore Input Shapers is not installed!"
+        else
+          run "remove_restore_input_shapers" "remove_menu_ui_k1_2025"
         fi;;
 
 #      6)

--- a/scripts/menu/K1_2025/remove_menu_K1C_2025.sh
+++ b/scripts/menu/K1_2025/remove_menu_K1C_2025.sh
@@ -21,6 +21,7 @@ function remove_menu_ui_k1_2025() {
   menu_option ' 7' 'Remove' 'USB Camera Support'
   menu_option ' 8' 'Remove' 'Built-in Camera Fix'
   menu_option ' 9' 'Remove' 'Camera Settings Control'
+  menu_option '10' 'Remove' 'Moonraker Timelapse'
 #  hr
 #  subtitle '•IMPROVEMENTS:'
 #  disabled_menu_option ' 6' 'Remove' 'Klipper Adaptive Meshing & Purging'
@@ -151,6 +152,12 @@ function remove_menu_k1_2025() {
           error_msg "Camera Settings Control is not installed!"
         else
           run "remove_camera_settings_control" "remove_menu_ui_k1_2025"
+        fi;;
+      10)
+        if [ ! -f "$TIMELAPSE_FILE" ]; then
+          error_msg "Moonraker Timelapse is not installed!"
+        else
+          run "remove_moonraker_timelapse" "remove_menu_ui_k1_2025"
         fi;;
 
 #      6)

--- a/scripts/menu/system_menu.sh
+++ b/scripts/menu/system_menu.sh
@@ -64,8 +64,16 @@ function system_menu_ui() {
   uptime=`cat /proc/uptime | cut -f1 -d.`
   formatted_uptime=$(format_uptime $uptime)
   load=`awk -v cpus=2 '{printf "%.2f%% (1 min) | %.2f%% (5 min) | %.2f%% (15 min)\n", $1*100/cpus, $2*100/cpus, $3*100/cpus}' /proc/loadavg`
-  device_sn=$(cat /usr/data/creality/userdata/config/system_config.json | grep -o '"device_sn":"[^"]*' | awk -F '"' '{print $4}')
-  mac_address=$(cat /usr/data/creality/userdata/config/system_config.json | grep -o '"device_mac":"[^"]*' | awk -F '"' '{print $4}' | sed 's/../&:/g; s/:$//')
+  if [ "$model" = "K1_2025" ]; then
+    # 2025 firmware dropped system_config.json (same as system_version.json); SN/MAC
+    # come from get_sn_mac.sh, the helper detect_model already uses.
+    device_sn=$(get_sn_mac.sh sn 2>/dev/null)
+    mac_address=$(get_sn_mac.sh mac 2>/dev/null | sed 's/../&:/g; s/:$//')
+  else
+    sysconf="/usr/data/creality/userdata/config/system_config.json"
+    device_sn=$(grep -o '"device_sn":"[^"]*' "$sysconf" 2>/dev/null | awk -F '"' '{print $4}')
+    mac_address=$(grep -o '"device_mac":"[^"]*' "$sysconf" 2>/dev/null | awk -F '"' '{print $4}' | sed 's/../&:/g; s/:$//')
+  fi
   top_line
   title '[ SYSTEM MENU ]' "${yellow}"
   inner_line

--- a/scripts/menu/system_menu.sh
+++ b/scripts/menu/system_menu.sh
@@ -2,12 +2,21 @@
 
 set -e
 
+# K1_2025 firmware dropped system_version.json and keeps the build string in
+# /etc/version instead, so branch on $model like the rest of the script.
+# NOTE: restore_input_shapers.sh gates on the K1_2025 branch returning the raw
+# /etc/version contents (it substring-matches the firmware build). Keep that
+# branch verbatim - don't reformat or strip it without updating the gate.
 function check_fw_version() {
-  file="/usr/data/creality/userdata/config/system_version.json"
-  if [ -e "$file" ]; then
-    cat "$file" | jq -r '.sys_version'
+  if [ "$model" = "K1_2025" ]; then
+    cat /etc/version 2>/dev/null || echo -e "N/A"
   else
-    echo -e "N/A"
+    file="/usr/data/creality/userdata/config/system_version.json"
+    if [ -e "$file" ]; then
+      cat "$file" | jq -r '.sys_version'
+    else
+      echo -e "N/A"
+    fi
   fi
 }
 

--- a/scripts/moonraker_timelapse.sh
+++ b/scripts/moonraker_timelapse.sh
@@ -29,12 +29,27 @@ function install_moonraker_timelapse(){
         fi
         echo -e "Info: Linking file..."
         ln -sf "$TIMELAPSE_URL1" "$TIMELAPSE_FILE"
-        ln -sf "$TIMELAPSE_URL2" "$HS_CONFIG_FOLDER"/timelapse.cfg
+        if [ "$model" = "K1_2025" ]; then
+          # K1_2025 runs Klipper as the unprivileged 'creality' user, which cannot read a
+          # symlink whose target is in the root-owned helper-script tree (Klipper then reports
+          # "Include file does not exist"). Use a real copy, and make the config dir
+          # traversable (mkdir under root's umask creates it mode 700).
+          chmod 755 "$HS_CONFIG_FOLDER"
+          cp -f "$TIMELAPSE_URL2" "$HS_CONFIG_FOLDER"/timelapse.cfg
+          chmod 644 "$HS_CONFIG_FOLDER"/timelapse.cfg
+        else
+          ln -sf "$TIMELAPSE_URL2" "$HS_CONFIG_FOLDER"/timelapse.cfg
+        fi
         if grep -q "include Helper-Script/timelapse" "$PRINTER_CFG" ; then
           echo -e "Info: Moonraker Timelapse configurations are already enabled in printer.cfg file..."
-        else
+        elif grep -q "\[include printer_params\.cfg\]" "$PRINTER_CFG" ; then
           echo -e "Info: Adding Moonraker Timelapse configurations in printer.cfg file..."
           sed -i '/\[include printer_params\.cfg\]/a \[include Helper-Script/timelapse\.cfg\]' "$PRINTER_CFG"
+        else
+          # K1_2025 ships a monolithic printer.cfg without the printer_params anchor;
+          # prepend the include (owner-preserving rewrite so Klipper SAVE_CONFIG keeps working).
+          echo -e "Info: Adding Moonraker Timelapse configurations in printer.cfg file..."
+          { echo "[include Helper-Script/timelapse.cfg]"; cat "$PRINTER_CFG"; } > "$PRINTER_CFG.hs_tmp" && cat "$PRINTER_CFG.hs_tmp" > "$PRINTER_CFG" && rm -f "$PRINTER_CFG.hs_tmp"
         fi
         if grep -q "#\[timelapse\]" "$MOONRAKER_CFG" ; then
           echo -e "Info: Enabling Moonraker Timelapse configurations in moonraker.conf file..."
@@ -44,6 +59,19 @@ function install_moonraker_timelapse(){
         fi
         echo -e "Info: Updating ffmpeg..."
         "$ENTWARE_FILE" update && "$ENTWARE_FILE" upgrade ffmpeg
+        if [ "$model" = "K1_2025" ]; then
+          # The timelapse component is loaded by Moonraker at startup, so Moonraker must be
+          # restarted (not just Klipper) for it to register. S56moonraker_service has no
+          # 'restart' verb, so stop + start. Run it in a subshell with umask 022: the
+          # Creality root shell defaults to umask 077, and a Moonraker started that way writes
+          # g-code uploads mode 600 — unreadable by the unprivileged 'creality' Klipper user,
+          # so prints fail with XD5027 "Unable to open file".
+          echo -e "Info: Restarting Moonraker service..."
+          ( umask 022
+            "$INITD_FOLDER"/S56moonraker_service stop 2>/dev/null
+            sleep 1
+            "$INITD_FOLDER"/S56moonraker_service start 2>/dev/null ) || true
+        fi
         echo -e "Info: Restarting Klipper service..."
         restart_klipper
         ok_msg "Moonraker Timelapse has been installed successfully!"

--- a/scripts/paths.sh
+++ b/scripts/paths.sh
@@ -113,6 +113,10 @@ function set_paths() {
   # Improved Shapers Calibrations #
   IMP_SHAPERS_FOLDER="${HS_CONFIG_FOLDER}/improved-shapers"
   IMP_SHAPERS_URL="${HS_FILES}/improved-shapers"
+
+  # Restore Input Shapers (K1C 2025) #
+  RESTORE_SHAPERS_URL="${HS_FILES}/restore-input-shapers/shaper_defs.py"
+  SHAPER_DEFS_FILE="${KLIPPER_EXTRAS_FOLDER}/shaper_defs.py"
   
   # Useful Macros #
   USEFUL_MACROS_FILE="${HS_CONFIG_FOLDER}/useful-macros.cfg"

--- a/scripts/restore_input_shapers.sh
+++ b/scripts/restore_input_shapers.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+set -e
+
+function restore_input_shapers_message(){
+  top_line
+  title 'Restore Input Shapers' "${yellow}"
+  inner_line
+  hr
+  echo -e " │ ${cyan}The K1C 2025 firmware ships input-shaper calibration limited ${white}│"
+  echo -e " │ ${cyan}to a single model (ei) and copies the Y-axis result onto X. ${white}│"
+  echo -e " │ ${cyan}This restores the full Klipper shaper model set and          ${white}│"
+  echo -e " │ ${cyan}independent per-axis calibration.                            ${white}│"
+  hr
+  bottom_line
+}
+
+function install_restore_input_shapers(){
+  restore_input_shapers_message
+  local yn
+  while true; do
+    install_msg "Restore Input Shapers" yn
+    case "${yn}" in
+      Y|y)
+        echo -e "${white}"
+        # 1. Restore the full shaper model set.
+        # Creality's compiled shaper_defs.pyc trims INPUT_SHAPERS down to 'ei', so
+        # SHAPER_CALIBRATE only ever fits ei. Dropping the stock shaper_defs.py beside it
+        # makes Python load the source (a legacy .pyc next to source is ignored when the
+        # .py is present), restoring zv/mzv/ei/2hump_ei/3hump_ei. shaper_calibrate.pyc
+        # already knows every model; only the definitions list was stripped.
+        echo -e "Info: Restoring full input-shaper model set..."
+        cp -f "$RESTORE_SHAPERS_URL" "$SHAPER_DEFS_FILE"
+        chmod 644 "$SHAPER_DEFS_FILE"
+        chown creality:creality "$SHAPER_DEFS_FILE" 2>/dev/null || true
+        rm -f "$KLIPPER_EXTRAS_FOLDER"/__pycache__/shaper_defs.*pyc 2>/dev/null || true
+        # 2. Calibrate X and Y independently (Creality copies Y->X by default via the
+        # resonance_tester 'axis_x_use_y' option, which defaults to true).
+        if grep -q "^[[:space:]]*axis_x_use_y" "$PRINTER_CFG" ; then
+          echo -e "Info: Independent X/Y calibration is already enabled in printer.cfg file..."
+        elif grep -q "^\[resonance_tester\]" "$PRINTER_CFG" ; then
+          echo -e "Info: Enabling independent X/Y calibration in printer.cfg file..."
+          awk '{print} /^\[resonance_tester\]/{print "axis_x_use_y: false"}' "$PRINTER_CFG" > "$PRINTER_CFG.hs_tmp" && cat "$PRINTER_CFG.hs_tmp" > "$PRINTER_CFG" && rm -f "$PRINTER_CFG.hs_tmp"
+        else
+          echo -e "${red}Warning: no [resonance_tester] section in printer.cfg; skipping axis_x_use_y.${white}"
+        fi
+        echo -e "Info: Restarting Klipper service..."
+        restart_klipper
+        ok_msg "Restore Input Shapers has been installed successfully!"
+        echo -e " ${cyan}Run ${white}SHAPER_CALIBRATE${cyan} from the console, then ${white}SAVE_CONFIG${cyan} to apply.${white}"
+        return;;
+      N|n)
+        error_msg "Installation canceled!"
+        return;;
+      *)
+        error_msg "Please select a correct choice!";;
+    esac
+  done
+}
+
+function remove_restore_input_shapers(){
+  restore_input_shapers_message
+  local yn
+  while true; do
+    remove_msg "Restore Input Shapers" yn
+    case "${yn}" in
+      Y|y)
+        echo -e "${white}"
+        echo -e "Info: Removing restored shaper definitions (Creality's shaper_defs.pyc takes over again)..."
+        rm -f "$SHAPER_DEFS_FILE"
+        rm -f "$KLIPPER_EXTRAS_FOLDER"/__pycache__/shaper_defs.*pyc 2>/dev/null || true
+        if grep -q "^[[:space:]]*axis_x_use_y" "$PRINTER_CFG" ; then
+          echo -e "Info: Disabling independent X/Y calibration in printer.cfg file..."
+          grep -v "^[[:space:]]*axis_x_use_y" "$PRINTER_CFG" > "$PRINTER_CFG.hs_tmp" && cat "$PRINTER_CFG.hs_tmp" > "$PRINTER_CFG" && rm -f "$PRINTER_CFG.hs_tmp"
+        else
+          echo -e "Info: Independent X/Y calibration is already disabled in printer.cfg file..."
+        fi
+        echo -e "Info: Restarting Klipper service..."
+        restart_klipper
+        ok_msg "Restore Input Shapers has been removed successfully!"
+        return;;
+      N|n)
+        error_msg "Deletion canceled!"
+        return;;
+      *)
+        error_msg "Please select a correct choice!";;
+    esac
+  done
+}

--- a/scripts/restore_input_shapers.sh
+++ b/scripts/restore_input_shapers.sh
@@ -5,8 +5,9 @@ set -e
 # Firmware builds whose stock Klipper this restore is verified against. A future
 # Creality firmware could ship a different shaper_defs (or react differently to the
 # change), so klippy is only modified on known-good versions, matched as a substring
-# of /etc/version. Space-separated; extend as builds are confirmed. Anyone on an
-# unlisted build is asked to report it first rather than have klippy touched blindly.
+# of the reported firmware (check_fw_version, which returns /etc/version on the
+# K1_2025). Space-separated; extend as builds are confirmed. Anyone on an unlisted
+# build is asked to report it first rather than have klippy touched blindly.
 RESTORE_SHAPERS_SUPPORTED_FW="V1.0.0.22.20250711S"
 
 function restore_input_shapers_message(){
@@ -31,7 +32,7 @@ function install_restore_input_shapers(){
       Y|y)
         echo -e "${white}"
         # Bail out on unverified firmware before touching klippy (see note at top).
-        fw="$(cat /etc/version 2>/dev/null)"
+        fw="$(check_fw_version)"
         verified=""
         for v in $RESTORE_SHAPERS_SUPPORTED_FW ; do
           if echo "$fw" | grep -qF "$v" ; then

--- a/scripts/restore_input_shapers.sh
+++ b/scripts/restore_input_shapers.sh
@@ -2,6 +2,13 @@
 
 set -e
 
+# Firmware builds whose stock Klipper this restore is verified against. A future
+# Creality firmware could ship a different shaper_defs (or react differently to the
+# change), so klippy is only modified on known-good versions, matched as a substring
+# of /etc/version. Space-separated; extend as builds are confirmed. Anyone on an
+# unlisted build is asked to report it first rather than have klippy touched blindly.
+RESTORE_SHAPERS_SUPPORTED_FW="V1.0.0.22.20250711S"
+
 function restore_input_shapers_message(){
   top_line
   title 'Restore Input Shapers' "${yellow}"
@@ -23,6 +30,23 @@ function install_restore_input_shapers(){
     case "${yn}" in
       Y|y)
         echo -e "${white}"
+        # Bail out on unverified firmware before touching klippy (see note at top).
+        fw="$(cat /etc/version 2>/dev/null)"
+        verified=""
+        for v in $RESTORE_SHAPERS_SUPPORTED_FW ; do
+          if echo "$fw" | grep -qF "$v" ; then
+            verified="1"
+            break
+          fi
+        done
+        if [ -z "$verified" ]; then
+          error_msg "Restore Input Shapers is not verified for this firmware yet!"
+          echo -e " ${cyan}Detected firmware: ${white}${fw:-unknown}${white}"
+          echo -e " ${cyan}Verified firmware: ${white}${RESTORE_SHAPERS_SUPPORTED_FW}${white}"
+          echo -e " ${cyan}Please report your version so it can be vetted and added:${white}"
+          echo -e " ${cyan}https://github.com/C0DEbrained/Creality-Helper-Script-2025/issues${white}"
+          return
+        fi
         # 1. Restore the full shaper model set.
         # Creality's compiled shaper_defs.pyc trims INPUT_SHAPERS down to 'ei', so
         # SHAPER_CALIBRATE only ever fits ei. Dropping the stock shaper_defs.py beside it

--- a/scripts/restore_input_shapers.sh
+++ b/scripts/restore_input_shapers.sh
@@ -44,8 +44,8 @@ function install_restore_input_shapers(){
           error_msg "Restore Input Shapers is not verified for this firmware yet!"
           echo -e " ${cyan}Detected firmware: ${white}${fw:-unknown}${white}"
           echo -e " ${cyan}Verified firmware: ${white}${RESTORE_SHAPERS_SUPPORTED_FW}${white}"
-          echo -e " ${cyan}Please report your version so it can be vetted and added:${white}"
-          echo -e " ${cyan}https://github.com/C0DEbrained/Creality-Helper-Script-2025/issues${white}"
+          echo -e " ${cyan}Please report your version on Discord so it can be vetted and added:${white}"
+          echo -e " ${cyan}https://discord.gg/BznpvBfrnw${white}"
           return
         fi
         # 1. Restore the full shaper model set.


### PR DESCRIPTION
Stacks on #8.

The K1C 2025's stock firmware ships input-shaper calibration crippled: Creality's compiled `shaper_defs.pyc` trims Klipper's shaper set down to a single model (`ei`), and `[resonance_tester]` copies the Y-axis result onto X — so `SHAPER_CALIBRATE` never tries `mzv`/`2hump_ei`/`3hump_ei` and never measures X independently. On a CoreXY whose X axis is more multi-modal than Y, that single forced `ei` fits poorly and the copied frequency doesn't shape X's real resonance at all.

The fix is small and config-level. Drop the stock upstream `shaper_defs.py` next to Creality's `.pyc` — Python loads the source and ignores the legacy `.pyc`, restoring the full `zv`/`mzv`/`ei`/`2hump_ei`/`3hump_ei` set. `shaper_calibrate.pyc` already knows every model; only the definitions list was stripped. Then set `axis_x_use_y: false` in `[resonance_tester]` so X and Y calibrate independently. No binary is replaced and nothing in the no-recovery partitions is touched; removing the feature deletes `shaper_defs.py` (Creality's `.pyc` resumes) and strips the config line.

It is wired as a new K1C 2025 menu option 11 (Install/Remove) plus an info-menu status line, mirroring the existing feature pattern. It deliberately does **not** pull in the K1 "Improved Shapers" graph tooling — that depends on a matplotlib `ft2font` build for 2.2.3 while the 2025 ships 3.0.3, so PSD graphs are out of scope here.

Validated on a K1C 2025 (FW V1.0.0.22.20250711S): the two operations were applied by hand, Klipper restarted clean, and `SHAPER_CALIBRATE` then fitted all five models per axis (X recommended `3hump_ei`, Y `zv` — independent, no copy). The menu wiring itself was not click-tested end-to-end.

## Test plan
- [x] `sh -n` clean on all changed scripts (paths, the new feature script, install/remove/info menus)
- [x] Both operations hardware-verified on a K1C 2025: stock `shaper_defs.py` shadows the trimmed `.pyc` → five models fit; `axis_x_use_y: false` → independent X/Y; Klipper restarts to `ready`
- [ ] Install **and** Remove run through the helper TUI (option 11) — not click-tested

## Manual test pass
- [ ] Install → 11 on a K1C 2025, run `SHAPER_CALIBRATE`, confirm all five models fit per-axis and X/Y differ
- [ ] Remove → 11, confirm `shaper_defs.py` is gone and Klipper still boots (Creality `.pyc` resumes)
