### PR TITLE
fix: correct System Menu ps error and RAM line on K1_2025

### DIFF
--- a/scripts/menu/system_menu.sh
+++ b/scripts/menu/system_menu.sh
@@ -47,11 +47,12 @@ function format_uptime() {
 }
 
 function system_menu_ui() {
-  memfree=`cat /proc/meminfo | grep MemFree | awk {'print $2'}`
+  memavail=`cat /proc/meminfo | grep MemAvailable | awk {'print $2'}`
+  [ -z "$memavail" ] && memavail=`cat /proc/meminfo | grep MemFree | awk {'print $2'}`
   memtotal=`cat /proc/meminfo | grep MemTotal | awk {'print $2'}`
-  pourcent=$((($memfree * 100)/$memtotal))
+  pourcent=$((($memavail * 100)/$memtotal))
   diskused=`df -h | grep /dev/mmcblk0p10 | awk {'print $3 " / " $2 " (" $4 " available)" '}`
-  process=`ps ax | wc -l | tr -d " "`
+  process=`ps | wc -l | tr -d " "`
   uptime=`cat /proc/uptime | cut -f1 -d.`
   formatted_uptime=$(format_uptime $uptime)
   load=`awk -v cpus=2 '{printf "%.2f%% (1 min) | %.2f%% (5 min) | %.2f%% (15 min)\n", $1*100/cpus, $2*100/cpus, $3*100/cpus}' /proc/loadavg`
@@ -68,7 +69,7 @@ function system_menu_ui() {
   system_line " IP Address" "$(check_connection)"
   system_line "MAC Address" "$mac_address"
   system_line "  CPU Usage" "$load"
-  system_line "  RAM Usage" "$(($memfree/1024)) MB / $(($memtotal/1024)) MB ($pourcent% available)"
+  system_line "   RAM Free" "$(($memavail/1024)) MB / $(($memtotal/1024)) MB ($pourcent% available)"
   system_line " Disk Usage" "$diskused"
   system_line "     Uptime" "$formatted_uptime"
   hr


### PR DESCRIPTION
While reviewing the input-shaper PR (#9) I noticed two unrelated, pre-existing bugs in the System Menu that show up on the K1 2025. Splitting them out here to keep that PR focused.

The first is a `ps ax` call used to count processes. The 2025's busybox `ps` rejects the `ax` operand and prints `ps: invalid option -- 'a'` straight into the menu. Plain `ps` already lists all processes on busybox, so the count works without the operand. Verified on a real 2025: plain `ps | wc -l` returns ~98.

The second is the RAM line. It read `MemFree` from `/proc/meminfo` but labelled the row "RAM Usage" while the value suffix said "available" — contradictory, and `MemFree` badly understates real headroom because it ignores reclaimable cache. On a real 2025 (`MemTotal 205408 kB`, `MemFree ~4900 kB`, `MemAvailable 66740 kB`) the old math reports ~2% when the kernel's own `MemAvailable` says ~32%. This switches to `MemAvailable` (falling back to `MemFree` on kernels that lack it) and relabels the row "RAM Free" so the label and the "available" semantics agree. The label stays padded to the same 11-char width so the colon column keeps aligning.

Neither fix is model-specific — plain `ps` and `MemAvailable` work on all targeted models — so no `$model` branching was needed.

## Test plan
- [x] `sh -n scripts/menu/system_menu.sh` passes
- [x] Confirmed on a real 2025 (`root@192.168.0.76`, read-only): plain `ps | wc -l` works and `/proc/meminfo` exposes `MemAvailable` (66740 kB), yielding 65 MB / 200 MB (32% available)

## Manual test pass
- [ ] Open `helper.sh` → System Menu and confirm no `ps: invalid option` error appears
- [ ] Confirm the RAM line reads sensibly (e.g. `65 MB / 200 MB (32% available)`) and the menu columns stay aligned
