### PR TITLE
fix: put git on Moonraker's PATH at boot so update_manager git repos validate

### DIFF
--- a/files/services/S56moonraker_service
+++ b/files/services/S56moonraker_service
@@ -13,6 +13,9 @@ PRINTER_LOGS_DIR=$PRINTER_DATA_DIR/logs
 PID_FILE=/var/run/moonraker.pid
 
 start() {
+        export PATH="/opt/bin:/opt/sbin:$PATH"
+        HOME=/root /opt/bin/git config --global --add safe.directory '*' >/dev/null 2>&1
+
         [ -d $PRINTER_DATA_DIR ] || mkdir -p $PRINTER_DATA_DIR
         [ -d $PRINTER_CONFIG_DIR ] || mkdir -p $PRINTER_CONFIG_DIR
         [ -d $PRINTER_LOGS_DIR ] || mkdir -p $PRINTER_LOGS_DIR


### PR DESCRIPTION

<img width="1968" height="1052" alt="image" src="https://github.com/user-attachments/assets/654d0d5c-28ff-4df8-a48a-8e0105c81561" />


Moonraker's Software Updates panel shows Creality-Helper-Script and moonraker as INVALID / "No git repo detected at configured path" after any power cycle, while `type: web` entries like fluidd stay fine.

The K1_2025 Moonraker launcher (`files/services/S56moonraker_service`) starts Moonraker with a PATH that has no `/opt/bin`, where Entware's `git` — the only git on the box — lives. Started from the helper menu the service inherits the interactive shell's `/etc/profile` PATH (which `entware.sh` already patches with `/opt/bin`), so git resolves and updates work; that's why it looks fine right after install. But at boot, init runs the service with no `/etc/profile`, `/opt/bin` drops off PATH, git can't be found, and every `git_repo` updater goes INVALID until someone restarts Moonraker from a login shell. A second-order issue surfaces once git is back on PATH: Moonraker runs as root while the managed repos are owned by `creality`, which trips git's dubious-ownership guard.

This exports `/opt/bin:/opt/sbin` in `start()` (mirroring the convention `entware.sh` uses for `/etc/profile`) and registers a `safe.directory` exception so the root-run daemon can operate the creality-owned repos. The fix is confined to the launcher; no other install behavior changes.

## Test plan
- [x] `sh -n files/services/S56moonraker_service` passes
- [ ] Manual test pass (see checklist below)

## Manual test pass
- [ ] Fresh K1_2025 install, then power-cycle the printer. Open Fluidd/Mainsail → Software Updates and confirm Creality-Helper-Script and moonraker show a valid version (not INVALID / "No git repo detected").
- [ ] On the printer: `tr '\0' '\n' < /proc/$(pidof -s python)/environ | grep PATH` (or the moonraker PID) shows `/opt/bin` present.
