### PR TITLE
Fix supervisord_cli shim on K1C 2025: install real file (no dangling symlink), robust INITD_PATH + service discovery

### DIFF
--- a/files/fixes/supervisorctl
+++ b/files/fixes/supervisorctl
@@ -1,9 +1,22 @@
 #!/bin/sh
-# supervisorctl shim - by destinal 
-# this is a fake supervisorctl that provides just enough information for moonraker to think it's the real thing.
-# good enough to list the names of services in moonraker.conf, to say whether they're running or not (with false pids and times)
-# and to start and stop them by name, finding and calling the matching init scripts. 
-# installing: put this in in /usr/bin/supervisorctl and then in moonraker.conf in [machine] section, set  "provider: supervisord_cli"
+# supervisorctl shim - originally by destinal (C0DEbrained helper-script fork)
+# A fake supervisorctl: enough for Moonraker's [machine] provider:supervisord_cli
+# to list services, report RUNNING/STOPPED, and start/stop/restart them by name
+# via the matching CrealityOS init.d script -- no real supervisord/systemd needed.
+#
+# Patched for the CrealityOS K1C 2025 (Arlo, 2026-07-01). Two upstream bugs on
+# the 2025 fixed here:
+#   1. INITD_PATH detection. Upstream gates on
+#        [ "$(get_sn_mac.sh model || get_sn_mac.sh model_str)" = "K1C" ]
+#      but on the 2025 `get_sn_mac.sh model` prints nothing yet returns rc 0, so
+#      the `||` short-circuits and the model_str fallback ("K1C") never runs ->
+#      INITD_PATH stays /etc/init.d (empty on the 2025) -> zero services found.
+#      Replaced with content-based detection: pick whichever init.d dir actually
+#      holds the moonraker service script.
+#   2. Service-name discovery. CrealityOS names klipper CS55klipper_service
+#      (C-prefixed); upstream's `S*` / `S[0-9][0-9]name` globs never match it.
+#      Discovery now also matches a leading capital before the runlevel and
+#      ignores .bak/.bkp/.orig backups left in init.d.
 
 if [ -t 1 ]; then  # colorize only if we're on a terminal
   GREEN='\033[32m'
@@ -11,21 +24,26 @@ if [ -t 1 ]; then  # colorize only if we're on a terminal
   ENDCOLOR='\033[0m'
 fi
 
+# --- locate the init.d directory that actually holds the service scripts ---
 INITD_PATH="/etc/init.d"
-if [ "$(get_sn_mac.sh "model" || get_sn_mac.sh "model_str")" = "K1C" ]; then
-  INITD_PATH="/usr/apps/etc/init.d"
-fi
+for _p in /usr/apps/etc/init.d /etc/appetc/init.d /etc/init.d; do
+  if ls "$_p"/*moonraker_service >/dev/null 2>&1; then
+    INITD_PATH="$_p"
+    break
+  fi
+done
+
+# strip dir, leading runlevel prefix (S56, CS55, ...) and _service suffix
+_svc_name() {
+  sed 's#.*/##; s/^[A-Za-z][A-Za-z]*[0-9][0-9]*//; s/_service$//'
+}
 
 get_services() {
-  moonraker_pid="$(cat /var/run/moonraker.pid)"
-  # if moonraker is running, get its config directory from its command line
+  moonraker_pid="$(cat /var/run/moonraker.pid 2>/dev/null)"
+  # if moonraker is running, confirm via its PID file before reporting
   if [ -f /var/run/moonraker.pid ] && [ -d /proc/"$moonraker_pid" ] ; then
-    cmdline="$(tr '\0' '\n' < /proc/"$moonraker_pid"/cmdline)"
-    moonraker_dir="$(echo $cmdline | awk -F'-d ' '{print $2}' | awk '{print $1}')"
-    moonraker_conf="$moonraker_dir/config/moonraker.conf"
-    # services="klipper moonraker $(awk '/managed_services:/ {print $2}' $moonraker_conf | sed 's/://')"
-    # services=`(printf 'klipper\nmoonraker\n'; awk '/managed_services:/ {print $2}' $moonraker_conf | sed 's/://') | sort|uniq`
-    services=$(ls -1 ${INITD_PATH}/S*|sed 's/.*\/S..//;s/_service$//')
+    services=$(ls -1 ${INITD_PATH}/S[0-9][0-9]* ${INITD_PATH}/[A-Z]S[0-9][0-9]* 2>/dev/null \
+               | grep -vE '\.(bak|bkp|orig)' | _svc_name | sort -u)
     echo $services
   else
     echo "Error: Invalid or missing PID file /var/run/moonraker.pid" >&2
@@ -33,24 +51,21 @@ get_services() {
   fi
 }
 
-get_pid_file() {
-  service="$1"
-  [ $service == "klipper" ] && service="klippy"
-  pid_file="/var/run/$service.pid"
-  echo $pid_file
-}
-
 is_running() {
   service="$1"
-  pid_file="$(get_pid_file "$service")"
+  daemon="$service"
+  [ "$service" == "klipper" ] && daemon="klippy"
 
-  # Check for PID file
-  if [ -f "$pid_file" ] && [ -d "/proc/$(cat $pid_file)" ]; then
+  # Check known PID-file locations. CrealityOS writes klipper's pid to
+  # /home/creality/run/klippy.pid (not /var/run); moonraker/nginx use /var/run.
+  for pid_file in "/var/run/$daemon.pid" "/home/creality/run/$daemon.pid"; do
+    if [ -f "$pid_file" ] && [ -d "/proc/$(cat "$pid_file" 2>/dev/null)" ]; then
       return 0  # Running
-  fi
+    fi
+  done
 
-  # Fallback to using pidof in case the service doesn't use pid files
-  if pidof "$service" &>/dev/null; then
+  # Fallback to pidof in case the service doesn't use a pid file
+  if pidof "$daemon" &>/dev/null; then
       return 0  # Running
   fi
   return 1  # Not running
@@ -68,11 +83,17 @@ print_usage() {
   echo "supervisorctl shim - provide minimal support for moonraker so CrealityOS moonraker can start/stop without systemd"
   echo "Usage: $0 [command] <service>"
   echo "commands include status stop start restart"
-} 
+}
 
 get_script_path() {
   service="$1"
-  script_path="$(ls -1 ${INITD_PATH}/S[0-9][0-9]${service}_service ${INITD_PATH}/S[0-9][0-9]${service}* 2>/dev/null|head -1)"
+  script_path="$(ls -1 ${INITD_PATH}/S[0-9][0-9]${service}_service \
+                       ${INITD_PATH}/[A-Z]S[0-9][0-9]${service}_service \
+                       ${INITD_PATH}/S[0-9][0-9]${service} \
+                       ${INITD_PATH}/[A-Z]S[0-9][0-9]${service} \
+                       ${INITD_PATH}/S[0-9][0-9]${service}* \
+                       ${INITD_PATH}/[A-Z]S[0-9][0-9]${service}* 2>/dev/null \
+                  | grep -vE '\.(bak|bkp|orig)' | head -1)"
   echo "$script_path"
 }
 

--- a/scripts/moonraker_nginx.sh
+++ b/scripts/moonraker_nginx.sh
@@ -2,6 +2,32 @@
 
 set -e
 
+function install_helper_shims(){
+  # Install the supervisorctl/systemctl/sudo shims as real files (not symlinks):
+  # a symlink rooted at the helper-script folder dangles if that folder is later
+  # renamed, leaving a broken entry on PATH that Moonraker hits as FileNotFound.
+  echo -e "Info: Installing Supervisor Lite..."
+  cp -f "$SUPERVISOR_URL" "$SUPERVISOR_FILE"
+  chmod 755 "$SUPERVISOR_FILE"
+  # K1C 2025: BIN_FOLDER (/usr/apps/usr/bin) is only on Moonraker's PATH at boot.
+  # The launcher always prepends /opt/bin (Entware), so a copy there is found on
+  # manual restarts too. Guarded on Entware being mounted; no-op on other models.
+  if [ "$model" = "K1_2025" ] && [ -d /opt/bin ]; then
+    cp -f "$SUPERVISOR_URL" "$SUPERVISOR_OPT_FILE"
+    chmod 755 "$SUPERVISOR_OPT_FILE"
+  fi
+  echo -e "Info: Installing Host Controls Support..."
+  cp -f "$SUDO_URL" "$SUDO_FILE"
+  chmod 755 "$SUDO_FILE"
+  cp -f "$SYSTEMCTL_URL" "$SYSTEMCTL_FILE"
+  chmod 755 "$SYSTEMCTL_FILE"
+}
+
+function remove_helper_shims(){
+  rm -f "$SUPERVISOR_FILE" "$SUDO_FILE" "$SYSTEMCTL_FILE"
+  [ "$model" = "K1_2025" ] && rm -f "$SUPERVISOR_OPT_FILE"
+}
+
 function moonraker_nginx_message(){
   top_line
   title 'Moonraker and Nginx' "${yellow}"
@@ -82,14 +108,7 @@ function install_moonraker_nginx(){
         cd "$MOONRAKER_FOLDER"/moonraker
         chown -R root:root .
         git stash; git checkout master; git pull
-        echo -e "Info: Installing Supervisor Lite..."
-        chmod 755 "$SUPERVISOR_URL"
-        ln -sf "$SUPERVISOR_URL" "$SUPERVISOR_FILE"
-        echo -e "Info: Installing Host Controls Support..."
-        chmod 755 "$SUDO_URL"
-        chmod 755 "$SYSTEMCTL_URL"
-        ln -sf "$SUDO_URL" "$SUDO_FILE"
-        ln -sf "$SYSTEMCTL_URL" "$SYSTEMCTL_FILE"
+        install_helper_shims
         echo -e "Info: Starting Nginx service..."
         start_nginx
         echo -e "Info: Starting Moonraker service..."
@@ -126,9 +145,7 @@ function remove_moonraker_nginx(){
         rm -rf "$PRINTER_DATA_FOLDER"/comms
         rm -rf "$NGINX_FOLDER"
         rm -rf "$MOONRAKER_FOLDER"
-        rm -f "$SUPERVISOR_FILE"
-        rm -f "$SUDO_FILE"
-        rm -f "$SYSTEMCTL_FILE"
+        remove_helper_shims
         ok_msg "Moonraker and Nginx have been removed successfully!"
         return;;
       N|n)
@@ -182,14 +199,7 @@ function install_moonraker_3v3(){
         echo -e "Info: Applying changes from official repo..."
         cd "$MOONRAKER_FOLDER"/moonraker
         git stash; git checkout master; git pull
-        echo -e "Info: Installing Supervisor Lite..."
-        chmod 755 "$SUPERVISOR_URL"
-        ln -sf "$SUPERVISOR_URL" "$SUPERVISOR_FILE"
-        echo -e "Info: Installing Host Controls Support..."
-        chmod 755 "$SUDO_URL"
-        chmod 755 "$SYSTEMCTL_URL"
-        ln -sf "$SUDO_URL" "$SUDO_FILE"
-        ln -sf "$SYSTEMCTL_URL" "$SYSTEMCTL_FILE"
+        install_helper_shims
         echo -e "Info: Starting Nginx service..."
         start_nginx
         echo -e "Info: Starting Moonraker service..."
@@ -223,9 +233,7 @@ function remove_moonraker_3v3(){
         rm -f "$KLIPPER_CONFIG_FOLDER"/.moonraker.conf.bkp
         rm -f "$PRINTER_DATA_FOLDER"/.moonraker.uuid
         rm -f "$PRINTER_DATA_FOLDER"/moonraker.asvc
-        rm -f "$SUPERVISOR_FILE"
-        rm -f "$SUDO_FILE"
-        rm -f "$SYSTEMCTL_FILE"
+        remove_helper_shims
         if [ -f /etc/nginx/nginx.conf.backup ]; then
           echo -e "Info: Restoring stock Nginx configuration..."
           rm -f /etc/nginx/nginx.conf

--- a/scripts/paths.sh
+++ b/scripts/paths.sh
@@ -53,6 +53,7 @@ function set_paths() {
   
   # Supervisor Lite #
   SUPERVISOR_FILE="$BIN_FOLDER/supervisorctl"
+  SUPERVISOR_OPT_FILE="/opt/bin/supervisorctl"
   SUPERVISOR_URL="${HS_FILES}/fixes/supervisorctl"
 
   # Host Controls Support #


### PR DESCRIPTION
On the K1C 2025 a fresh Moonraker+Nginx install doesn't work out of the box: Moonraker's `[machine] provider: supervisord_cli` shells out to `supervisorctl`, which can't be found, so `moonraker.log` fills with `Command (supervisorctl status ) failed … FileNotFoundError … 'supervisorctl'` every ~2 seconds (~22,700 lines on the unit this was diagnosed on, CrealityOS firmware mips 5.10.186). Three independent causes had to be fixed.

First, the installer linked the shim into place with `ln -sf` rooted at the helper-script folder. If that folder is ever renamed, the symlink dangles, but it stays on `PATH`, so the kernel finds the link and `execve` returns ENOENT — surfacing as the FileNotFoundError above. The shim, `systemctl`, and `sudo` are now installed as real copies (`cp -f`), which can never dangle. The install/remove logic was duplicated across two install and two removal branches that could drift apart (the original source of this class of bug), so it's been factored into shared `install_helper_shims`/`remove_helper_shims` helpers.

Second, on the 2025 `BIN_FOLDER` is `/usr/apps/usr/bin`, which is only on Moonraker's `PATH` at boot — a manual `S56moonraker_service restart` inherits a `PATH` without `/usr/apps/*`, so the shim isn't found until the next reboot. The Moonraker launcher unconditionally prepends `/opt/bin` (Entware), making it the one directory on Moonraker's `PATH` in every case, so the 2025 now also gets a real copy of `supervisorctl` at `/opt/bin/supervisorctl`, guarded on Entware being mounted.

Third, the shim itself never worked on the 2025 even with a live target. Its init.d detection gated on `get_sn_mac.sh model || …model_str` equalling `K1C`, but on the 2025 `get_sn_mac.sh model` prints nothing and returns 0, so the `||` short-circuits and `INITD_PATH` stays at the empty `/etc/init.d`. It now picks whichever of `/usr/apps/etc/init.d`, `/etc/appetc/init.d`, `/etc/init.d` actually contains the moonraker service script. Service discovery also now matches CrealityOS's C-prefixed scripts (e.g. `CS55klipper_service`) and ignores `.bak`/`.bkp`/`.orig` backups, and `is_running` additionally checks `/home/creality/run/<daemon>.pid`, where CrealityOS writes klipper's pid. All of this is BusyBox ash-compatible, and everything stays model-gated so non-2025 models keep resolving to `/etc/init.d` and `/usr/bin` unchanged.

This was diagnosed and fixed on a live K1C 2025.

## Test plan
- [ ] Fresh K1C 2025 install of Moonraker+Nginx → no `supervisorctl … FileNotFoundError` lines in `moonraker.log`
- [ ] `supervisorctl status klipper moonraker nginx` → all RUNNING (resolves `CS55klipper_service`, `S56moonraker_service`, `S50nginx`)
- [ ] `GET /machine/system_info` → `available_services:["klipper","moonraker"]`, both `active_state: active`
- [ ] Non-2025 model install unaffected (shim resolves `/etc/init.d`, `/usr/bin`)

## Not addressed
`systemctl`/`sudo` get the symlink→real-copy fix but not the extra `/opt/bin` copy. The same PATH-at-boot fragility applies (the `[machine]` component shells `sudo` for shutdown/reboot), but only `supervisorctl` was verified on hardware, so the extra copy is scoped to it.
