### PR TITLE
Transition from tranducanh.com to entware.net

### DIFF
--- a/files/services/S50builtin_camera-k1c-2025
+++ b/files/services/S50builtin_camera-k1c-2025
@@ -4,8 +4,9 @@
 case "$1" in
   start)
     echo "Starting Built-in Camera..."
-    if [ ! -x /opt/bin/mjpg_streamer ]; then
-      echo "Error: mjpg_streamer not found in /opt/bin!"
+    # The built-in mjpg streamer is found in /usr/bin, not /opt/bin.
+    if [ ! -x /usr/bin/mjpg_streamer ]; then
+      echo "Error: mjpg_streamer not found in /usr/bin!"
       exit 1
     fi
     if [ ! -e /dev/video0 ]; then
@@ -16,9 +17,10 @@ case "$1" in
       /opt/etc/init.d/S96mjpg-streamer stop 2>/dev/null || true
       mv /opt/etc/init.d/S96mjpg-streamer /opt/etc/init.d/disabled.S96mjpg-streamer
     fi
+    # The -r flag seems to not be supported by the built-in mjpg streamer. It seems redundant anyway, and therefore I removed it.
     PIDS=$(ps | grep '[m]jpg_streamer' | grep -E 'input_uvc.so.*-d /dev/video0|output_http.so -p 3000|output_http.so -p 8080' | awk '{print $1}')
     [ -n "$PIDS" ] && kill $PIDS
-    /opt/bin/mjpg_streamer -b -i "/opt/lib/mjpg-streamer/input_uvc.so -d /dev/video0 -r 1280x720 -f 15" -o "/opt/lib/mjpg-streamer/output_http.so -p 8080"
+    /usr/bin/mjpg_streamer -b -i "/usr/lib/mjpg-streamer/input_uvc.so -d /dev/video0 -f 15" -o "/usr/lib/mjpg-streamer/output_http.so -p 8080"
     ;;
   stop)
     echo "Stopping Built-in Camera..."

--- a/files/services/S50usb_camera-k1c-2025
+++ b/files/services/S50usb_camera-k1c-2025
@@ -20,8 +20,9 @@ get_camera_resolution() {
 case "$1" in
   start)
     echo "Starting USB Camera..."
-    if [ ! -x /opt/bin/mjpg_streamer ]; then
-      echo "Error: mjpg_streamer not found in /opt/bin!"
+    # The built-in mjpg streamer is found in /usr/bin, not /opt/bin.
+    if [ ! -x /usr/bin/mjpg_streamer ]; then
+      echo "Error: mjpg_streamer not found in /usr/bin!"
       exit 1
     fi
     PORT=8082
@@ -34,7 +35,7 @@ case "$1" in
     for V4L_DEV in $V4L_DEVS; do
       RESOLUTION=$(get_camera_resolution "$V4L_DEV")
       echo "Starting $V4L_DEV at ${RESOLUTION} on port $PORT..."
-      /opt/bin/mjpg_streamer -b -i "/opt/lib/mjpg-streamer/input_uvc.so -d $V4L_DEV -r $RESOLUTION -f 15" -o "/opt/lib/mjpg-streamer/output_http.so -p $PORT"
+      /usr/bin/mjpg_streamer -b -i "/usr/lib/mjpg-streamer/input_uvc.so -d $V4L_DEV -f 15" -o "/usr/lib/mjpg-streamer/output_http.so -p $PORT"
       PORT=`expr $PORT + 1`
     done
     ;;

--- a/scripts/entware.sh
+++ b/scripts/entware.sh
@@ -78,7 +78,8 @@ function install_entware(){
           k1_2025_opt_mount
           $HS_FILES/fixes/curl -L "https://bin.entware.net/mipselsf-k3.4/installer/generic.sh" | sh
           export PATH=/opt/bin:/opt/sbin:$PATH
-          sed -i '1s|.*|src/gz entware http://bin.tranducanh.com/mipselsf-k3.4|' /opt/etc/opkg.conf
+          # I'm not sure why we were using Tranducanh.com. It got wiped and it broke everything. It makes more sense to just use the official one.
+          sed -i '1s|.*|src/gz entware http://bin.entware.net/mipselsf-k3.4|' /opt/etc/opkg.conf
           opkg update
 
           opkg install openssh-sftp-server

--- a/scripts/usb_camera.sh
+++ b/scripts/usb_camera.sh
@@ -78,13 +78,16 @@ EOF
 }
 
 function ensure_mjpg_streamer_packages(){
+  # K-series firmware already ships mjpg-streamer at /usr/bin (I tested this on my K1 Max and someone on discord checked on the K1C)
+  [ -x /usr/bin/mjpg_streamer ] && return
+
   if "$ENTWARE_FILE" list | grep -q '^mjpg-streamer '; then
     return
   fi
 
   if [ "$model" = "K1_2025" ]; then
     echo -e "Info: Updating Entware repository for mjpg-streamer packages..."
-    sed -i '1s|.*|src/gz entware http://bin.tranducanh.com/mipselsf-k3.4|' /opt/etc/opkg.conf
+    sed -i '1s|.*|src/gz entware http://bin.entware.net/mipselsf-k3.4|' /opt/etc/opkg.conf
     "$ENTWARE_FILE" update
   fi
 
@@ -173,11 +176,10 @@ function install_usb_camera(){
         fi
         chmod 755 "$USB_CAMERA_FILE"
         echo -e "Info: Installing necessary packages..."
-        ensure_mjpg_streamer_packages
-        "$ENTWARE_FILE" update && "$ENTWARE_FILE" install mjpg-streamer mjpg-streamer-input-http mjpg-streamer-input-uvc mjpg-streamer-output-http mjpg-streamer-www
-        disable_entware_builtin_mjpg_streamer
-        echo -e "Info: Starting service..."
-        "$USB_CAMERA_FILE" start
+        if [ ! -x /usr/bin/mjpg_streamer ]; then
+          ensure_mjpg_streamer_packages
+          "$ENTWARE_FILE" update && "$ENTWARE_FILE" install mjpg-streamer mjpg-streamer-input-http mjpg-streamer-input-uvc mjpg-streamer-output-http mjpg-streamer-www
+        fi
         if [ "$model" = "K1_2025" ]; then
           configure_usb_camera_k1_2025
           if [ -f "$INITD_FOLDER"/S56moonraker_service ]; then
@@ -185,6 +187,8 @@ function install_usb_camera(){
             start_moonraker
           fi
         fi
+        echo -e "Info: Starting service..."
+        "$USB_CAMERA_FILE" start
         ok_msg "USB Camera Support has been installed successfully!"
         return;;
       N|n)
@@ -218,16 +222,17 @@ function install_builtin_camera(){
         cp "$BUILTIN_CAMERA_K1_2025_URL" "$BUILTIN_CAMERA_FILE"
         chmod 755 "$BUILTIN_CAMERA_FILE"
         echo -e "Info: Installing necessary packages..."
-        ensure_mjpg_streamer_packages
-        "$ENTWARE_FILE" update && "$ENTWARE_FILE" install mjpg-streamer mjpg-streamer-input-http mjpg-streamer-input-uvc mjpg-streamer-output-http mjpg-streamer-www
-        disable_entware_builtin_mjpg_streamer
-        echo -e "Info: Starting service..."
-        "$BUILTIN_CAMERA_FILE" start
+        if [ ! -x /usr/bin/mjpg_streamer ]; then
+          ensure_mjpg_streamer_packages
+          "$ENTWARE_FILE" update && "$ENTWARE_FILE" install mjpg-streamer mjpg-streamer-input-http mjpg-streamer-input-uvc mjpg-streamer-output-http mjpg-streamer-www
+        fi
         configure_builtin_camera_k1_2025
         if [ -f "$INITD_FOLDER"/S56moonraker_service ]; then
           stop_moonraker
           start_moonraker
         fi
+        echo -e "Info: Starting service..."
+        "$BUILTIN_CAMERA_FILE" start
         ok_msg "Built-in Camera Fix has been installed successfully!"
         return;;
       N|n)


### PR DESCRIPTION
- Switch from downloading the mjpg_streamer package from entware to simply using the one that already comes with the firmware
- Drop -r flag in the Built-in mjpg streamer as it isn't a supported flag in the builtin package
- Switch from Tranducanh.com (which seems to have been taken down) to entware.net, the official file host for Entware.

I tested these changes on my K1 Max and I have no reason to believe it would not work on K1C printers.