### PR TITLE
fix(timelapse): exclude linked component from Moonraker repo

### DIFF
--- a/scripts/moonraker_timelapse.sh
+++ b/scripts/moonraker_timelapse.sh
@@ -29,6 +29,16 @@ function install_moonraker_timelapse(){
         fi
         echo -e "Info: Linking file..."
         ln -sf "$TIMELAPSE_URL1" "$TIMELAPSE_FILE"
+        # The linked component is an untracked source file inside Moonraker's git
+        # repo, so update_manager permanently reports the repo as dirty
+        # ("Repo has untracked source files: ['moonraker/components/timelapse.py']").
+        # Add it to the repo's local exclude list so update_manager stays happy.
+        MOONRAKER_REPO_DIR="${TIMELAPSE_FILE%/moonraker/components/timelapse.py}"
+        if [ -d "$MOONRAKER_REPO_DIR"/.git/info ]; then
+          echo -e "Info: Excluding linked component from Moonraker repo..."
+          grep -qxF "moonraker/components/timelapse.py" "$MOONRAKER_REPO_DIR"/.git/info/exclude 2>/dev/null \
+            || echo "moonraker/components/timelapse.py" >> "$MOONRAKER_REPO_DIR"/.git/info/exclude
+        fi
         if [ "$model" = "K1_2025" ]; then
           # K1_2025 runs Klipper as the unprivileged 'creality' user, which cannot read a
           # symlink whose target is in the root-owned helper-script tree (Klipper then reports
@@ -97,6 +107,11 @@ function remove_moonraker_timelapse(){
         rm -f "$HS_CONFIG_FOLDER"/timelapse.cfg
         rm -f /usr/data/moonraker/moonraker/moonraker/components/timelapse.py
         rm -f /usr/data/moonraker/moonraker/moonraker/components/timelapse.pyc
+        # Drop the local exclude entry added at install time (symmetry).
+        MOONRAKER_REPO_DIR="${TIMELAPSE_FILE%/moonraker/components/timelapse.py}"
+        if [ -f "$MOONRAKER_REPO_DIR"/.git/info/exclude ]; then
+          sed -i '/^moonraker\/components\/timelapse\.py$/d' "$MOONRAKER_REPO_DIR"/.git/info/exclude
+        fi
         if [ -f /opt/bin/ffmpeg ]; then
           set +e
           "$ENTWARE_FILE" --autoremove remove ffmpeg


### PR DESCRIPTION
Installing Moonraker Timelapse symlinks its component into Moonraker's own git
repo at `moonraker/components/timelapse.py`. Since Moonraker doesn't track that
file, `update_manager` then permanently reports the repo as dirty —
`Repo has untracked source files: ['moonraker/components/timelapse.py']` — which
clutters update status and can interfere with Moonraker updates, even though the
component is installed on purpose.

This adds the linked path to the Moonraker repo's `.git/info/exclude` at install
time so `update_manager` stops flagging it. The write is idempotent and guarded
on `.git/info` existing; the uninstall path removes the entry for symmetry. The
repo root and excluded path are derived from the existing `$TIMELAPSE_FILE`
variable rather than hardcoded.

Same change as Guilouz/Creality-Helper-Script#34, still open upstream — porting
it here so the 2025 fork doesn't wait on it. The added lines are identical; only
the surrounding context differs, since this fork carries the K1_2025 branches in
the same function.

## Test plan
- [x] `sh -n scripts/moonraker_timelapse.sh` passes
- [ ] On-device: install Moonraker Timelapse, confirm `update_manager` no longer reports the untracked-source anomaly
- [ ] On-device: re-run install, confirm the exclude entry is not duplicated (idempotent)
- [ ] On-device: uninstall, confirm the exclude entry is removed