### PR TITLE
Set umask 022 in S56moonraker_service so Helper Script restarts don't break uploads

### DIFF
--- a/files/services/S56moonraker_service
+++ b/files/services/S56moonraker_service
@@ -13,6 +13,14 @@ PRINTER_LOGS_DIR=$PRINTER_DATA_DIR/logs
 PID_FILE=/var/run/moonraker.pid
 
 start() {
+        # Klipper runs as the unprivileged 'creality' user on the K1 2025 while Moonraker
+        # runs as root, so g-code uploads are only usable if they land world-readable.
+        # Without this, Moonraker inherits the umask of whatever started it: boot gives it
+        # 022, but a restart from an SSH root shell (which is what the Helper Script's own
+        # Restart Moonraker action is) gives it the CrealityOS root default of 077. Uploads
+        # then land mode 600 and print start fails with XD5027 "Unable to open file".
+        umask 022
+
         export PATH="/opt/bin:/opt/sbin:$PATH"
         HOME=/root /opt/bin/git config --global --add safe.directory '*' >/dev/null 2>&1
 


### PR DESCRIPTION
Klipper runs as the unprivileged `creality` user on the K1 2025 while Moonraker runs as root, so g-code uploads are only usable if they land world-readable. `S56moonraker_service` never sets a umask, so Moonraker inherits it from whatever started it — and the Helper Script's own Restart Moonraker action runs from the operator's SSH root shell, where the CrealityOS default is 077. Every upload after such a restart lands mode 600 root:root and print start fails with `HTTP 400 XD5027 "Unable to open file"`.

This is not a boot-path problem: services started at boot already run with umask 022, and an upload handled by a boot-started Moonraker lands 644 and prints fine. The trigger is specifically a restart from an interactive root shell. `restart_moonraker_action()` in `scripts/tools.sh` is the obvious one, but `usb_camera.sh` stops and starts the service in four places and `moonraker_nginx.sh` installs and replaces it, all from that same shell. Setting the umask inside `start()` makes every one of those paths behave like boot.

The same fix already exists in-tree as a `( umask 022 ... )` subshell around the Moonraker restart in `scripts/moonraker_timelapse.sh`, added when this bit during timelapse setup. That wrapper stays as-is — this just moves the guarantee to the one place all callers go through.

Reproduce on a 2025:

```sh
umask 077 && /usr/apps/etc/init.d/S56moonraker_service restart
# upload any gcode via the web UI, then:
ls -l /usr/data/printer_data/gcodes/<uploaded>.gcode   # -rw------- root root
grep Umask /proc/$(cat /var/run/moonraker.pid)/status  # Umask: 0077
```

Read `Umask` from `/proc`, not the PID — PIDs on the 2025 wrap past 30000, so a hand-restarted Moonraker can draw a low, boot-looking PID.

## Test plan
- [x] `grep -c 'umask 022' files/services/S56moonraker_service` returns 1
- [x] `sh -n files/services/S56moonraker_service` passes
- [x] File mode unchanged (100755)
- [ ] On a 2025: Helper Script → Restart Moonraker → `grep Umask /proc/<pid>/status` reports 0022
- [ ] Upload a gcode after that restart → lands `-rw-r--r--`, print starts without XD5027

The last two were verified on my own 2025 with this exact line applied by hand — Moonraker came back `Umask: 0022` with `klippy_state: ready`, and a test upload landed `-rw-r--r--` and was readable as `creality` — but not re-run from this branch, so they stay unchecked.

## Not addressed
The other shipped init scripts (`S50nginx`, `S55klipper_service`, `CS55klipper_service_minimal`, the camera services) have the same missing-umask pattern. Moonraker is the one that writes user-visible files, so restricting this to it keeps the change reviewable; happy to do the rest as a follow-up.

The K1/K1C OG under `Guilouz/Creality-Helper-Script` can't hit this — Klipper runs as root there and can read 600 root-owned files regardless — so there's no matching upstream PR to make.
