### PR TITLE
Add a Block Creality Cloud Telemetry option

### DIFF
--- a/files/services/S995cloudblock
+++ b/files/services/S995cloudblock
@@ -1,0 +1,184 @@
+#!/bin/sh
+#
+# Block Creality Cloud Telemetry
+# Credit: C0DEbrained
+#
+# Blackholes the hosts the stock Creality daemons use for telemetry, remote
+# access and OTA checks, and drops outbound MQTT to anything off the LAN.
+#
+# Re-applied at every boot on purpose: iptables rules never survive a reboot on
+# any model, and on the K1 2025 the rootfs is a volatile RAM filesystem, so
+# /etc/hosts reverts to stock at every start.
+#
+# This is a blocklist, not a firewall. The OUTPUT policy is left untouched and
+# nothing else is filtered, so the cloud relay options the helper installs
+# (OctoEverywhere, Obico, GuppyFLO, SimplyPrint, OctoApp, Mobileraker) keep
+# working.
+
+HOSTS="/etc/hosts"
+MARKER="# Creality Helper Script - Block Creality Cloud Telemetry"
+MQTT_PORTS="1883 8883"
+
+# Hosts found in the stock vectorp and onyxp binaries, in alchemistp's
+# config.json, and on the wire during a print.
+BLACKHOLE="
+api.crealitycloud.com
+mqtt.crealitycloud.com
+cxsw-cdn.crealitycloud.com
+model-cdn.crealitycloud.com
+admin-pre.crealitycloud.com
+pre-tb-iot.crealitycloud.com
+www.crealitycloud.com
+api.crealitycloud.cn
+mqtt.crealitycloud.cn
+admin-pre.crealitycloud.cn
+api-dev.crealitycloud.cn
+www.crealitycloud.cn
+c-smart.cxswyjy.com
+c-smart-cn-local.cxswyjy.com
+devdata.cxswyjy.com
+www.creality.com
+"
+
+# The K1 and Ender-3 V3 series ship without an iptables binary even though the
+# kernel module is loaded, so every rule below is optional. The hosts blocklist
+# is applied either way.
+have_iptables() {
+  command -v iptables > /dev/null 2>&1 && iptables -L OUTPUT -n > /dev/null 2>&1
+}
+
+# Directly attached subnets, so a local MQTT broker stays reachable. Never
+# guess: no route, no LAN exemption.
+lan_networks() {
+  ip route 2>/dev/null | awk '/proto kernel/ && /src/ { print $1 }'
+}
+
+# ACCEPT rules are inserted at the top so they always precede the DROP rules,
+# even if the network came up after a first pass added the drops alone.
+accept_rule() {
+  iptables -C "$@" 2>/dev/null || iptables -I "$@"
+}
+
+drop_rule() {
+  iptables -C "$@" 2>/dev/null || iptables -A "$@"
+}
+
+delete_rule() {
+  while iptables -C "$@" 2>/dev/null; do
+    iptables -D "$@" 2>/dev/null || break
+  done
+}
+
+# Appending to a file whose last line has no newline would corrupt that line.
+hosts_end_with_newline() {
+  [ -s "$HOSTS" ] || return 0
+  [ -z "$(tail -c 1 "$HOSTS")" ] || printf '\n' >> "$HOSTS"
+}
+
+# Only ever matches the lines this script writes, so an entry a user added by
+# hand for the same host is left alone on removal.
+host_pattern() {
+  echo "^0\.0\.0\.0[[:space:]][[:space:]]*$(echo "$1" | sed 's/\./\\./g')\$"
+}
+
+hosts_block() {
+  local host
+  hosts_end_with_newline
+  grep -q "^${MARKER}\$" "$HOSTS" 2>/dev/null || printf '%s\n' "$MARKER" >> "$HOSTS"
+  for host in $BLACKHOLE; do
+    grep -q "$(host_pattern "$host")" "$HOSTS" 2>/dev/null || printf '0.0.0.0 %s\n' "$host" >> "$HOSTS"
+  done
+}
+
+hosts_unblock() {
+  local host
+  [ -f "$HOSTS" ] || return 0
+  for host in $BLACKHOLE; do
+    sed -i "/$(host_pattern "$host")/d" "$HOSTS"
+  done
+  sed -i "/^${MARKER}\$/d" "$HOSTS"
+}
+
+# At boot this can run before DHCP has finished, which would add the drops with
+# no LAN exemption and leave a local MQTT broker unreachable until the next
+# boot. Wait briefly, but never hold up a printer that has no network at all.
+wait_for_lan() {
+  local waited=0
+  while [ -z "$(lan_networks)" ] && [ "$waited" -lt 5 ]; do
+    sleep 1
+    waited=$((waited + 1))
+  done
+}
+
+mqtt_block() {
+  local lan
+  local port
+  have_iptables || return 0
+  wait_for_lan
+  for port in $MQTT_PORTS; do
+    # 127.0.0.1 is not in the LAN CIDR, and a blackholed host resolves to
+    # 0.0.0.0, which the kernel routes to loopback. Without this the drop below
+    # silently swallows that traffic instead of letting it fail fast with a
+    # RST. Every rule is scoped to an MQTT port so that removing it can never
+    # take out a broader rule another tool owns.
+    accept_rule OUTPUT -o lo -p tcp --dport "$port" -j ACCEPT
+    for lan in $(lan_networks); do
+      accept_rule OUTPUT -p tcp -d "$lan" --dport "$port" -j ACCEPT
+    done
+    # vectorp carries hardcoded broker IPs (47.114.48.45:1883 and
+    # 120.55.101.240:1883) that bypass DNS entirely, so the port rules are what
+    # actually stops it.
+    drop_rule OUTPUT -p tcp --dport "$port" -j DROP
+  done
+}
+
+mqtt_unblock() {
+  local lan
+  local port
+  have_iptables || return 0
+  for port in $MQTT_PORTS; do
+    delete_rule OUTPUT -p tcp --dport "$port" -j DROP
+    for lan in $(lan_networks); do
+      delete_rule OUTPUT -p tcp -d "$lan" --dport "$port" -j ACCEPT
+    done
+    delete_rule OUTPUT -o lo -p tcp --dport "$port" -j ACCEPT
+  done
+}
+
+case "$1" in
+  start)
+    echo "Blocking Creality cloud telemetry..."
+    hosts_block
+    mqtt_block
+    ;;
+  stop)
+    echo "Unblocking Creality cloud telemetry..."
+    mqtt_unblock
+    hosts_unblock
+    ;;
+  restart|force-reload)
+    "$0" stop
+    "$0" start
+    ;;
+  status)
+    blocked=0
+    total=0
+    for host in $BLACKHOLE; do
+      total=$((total + 1))
+      if grep -q "$(host_pattern "$host")" "$HOSTS" 2>/dev/null; then
+        blocked=$((blocked + 1))
+      fi
+    done
+    echo "Hosts blocklist: $blocked of $total entries present"
+    if have_iptables; then
+      iptables -L OUTPUT -v -n
+    else
+      echo "MQTT port rules: skipped (iptables not available)"
+    fi
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|force-reload|status}"
+    exit 1
+esac
+
+exit 0

--- a/files/services/S995cloudblock
+++ b/files/services/S995cloudblock
@@ -11,13 +11,24 @@
 # /etc/hosts reverts to stock at every start.
 #
 # This is a blocklist, not a firewall. The OUTPUT policy is left untouched and
-# nothing else is filtered, so the cloud relay options the helper installs
-# (OctoEverywhere, Obico, GuppyFLO, SimplyPrint, OctoApp, Mobileraker) keep
+# nothing else is filtered, so the cloud relay options the helper installs keep
 # working.
+#
+# Everything written here is owned and delimited: the hosts entries live between
+# two markers, the firewall rules live in their own chain. Nothing is matched by
+# content, so uninstall cannot remove a hosts line or a firewall rule that
+# something else created.
+
+# A root SSH shell on CrealityOS inherits umask 077 while boot uses 022, so pin
+# it here, same reason S56moonraker_service does.
+umask 022
 
 HOSTS="/etc/hosts"
-MARKER="# Creality Helper Script - Block Creality Cloud Telemetry"
+BEGIN_MARKER="# BEGIN Creality Helper Script - Block Creality Cloud Telemetry"
+END_MARKER="# END Creality Helper Script - Block Creality Cloud Telemetry"
+CHAIN="CREALITY_CLOUDBLOCK"
 MQTT_PORTS="1883 8883"
+LAN_WAIT_SECONDS=5
 
 # Hosts found in the stock vectorp and onyxp binaries, in alchemistp's
 # config.json, and on the wire during a print.
@@ -40,145 +51,202 @@ devdata.cxswyjy.com
 www.creality.com
 "
 
+IPT=""
+IPTABLES_STATE=""
+
 # The K1 and Ender-3 V3 series ship without an iptables binary even though the
-# kernel module is loaded, so every rule below is optional. The hosts blocklist
-# is applied either way.
-have_iptables() {
-  command -v iptables > /dev/null 2>&1 && iptables -L OUTPUT -n > /dev/null 2>&1
+# kernel module is loaded, which is a normal state this script tolerates. A
+# binary that is present but unusable is a real error and must not be reported
+# as "this model has no iptables".
+probe_iptables() {
+  [ -n "$IPTABLES_STATE" ] && return 0
+  if ! command -v iptables > /dev/null 2>&1; then
+    IPTABLES_STATE="absent"
+    return 0
+  fi
+  # -w serialises against anything else writing the same table. iptables 1.8
+  # knows the flag, older builds do not, so fall back rather than fail every
+  # call.
+  if iptables -w 5 -L OUTPUT -n > /dev/null 2>&1; then
+    IPT="iptables -w 5"
+    IPTABLES_STATE="ok"
+  elif iptables -L OUTPUT -n > /dev/null 2>&1; then
+    IPT="iptables"
+    IPTABLES_STATE="ok"
+  else
+    IPTABLES_STATE="error"
+  fi
+}
+
+ipt() {
+  $IPT "$@"
+}
+
+# Tested with -S rather than -C so this works on iptables builds predating -C.
+chain_is_linked() {
+  ipt -S OUTPUT 2>/dev/null | grep -q -- "-j $CHAIN"
 }
 
 # Directly attached subnets, so a local MQTT broker stays reachable. Never
-# guess: no route, no LAN exemption.
+# guess: no route, no LAN exemption. Matched on "src" plus a CIDR in the first
+# field rather than on "proto kernel", which not every ip implementation prints.
 lan_networks() {
-  ip route 2>/dev/null | awk '/proto kernel/ && /src/ { print $1 }'
+  ip route 2>/dev/null | awk '/[[:space:]]src[[:space:]]/ && $1 ~ /\// { print $1 }'
 }
 
-# ACCEPT rules are inserted at the top so they always precede the DROP rules,
-# even if the network came up after a first pass added the drops alone.
-accept_rule() {
-  iptables -C "$@" 2>/dev/null || iptables -I "$@"
-}
-
-drop_rule() {
-  iptables -C "$@" 2>/dev/null || iptables -A "$@"
-}
-
-delete_rule() {
-  while iptables -C "$@" 2>/dev/null; do
-    iptables -D "$@" 2>/dev/null || break
-  done
-}
-
-# Appending to a file whose last line has no newline would corrupt that line.
-hosts_end_with_newline() {
-  [ -s "$HOSTS" ] || return 0
-  [ -z "$(tail -c 1 "$HOSTS")" ] || printf '\n' >> "$HOSTS"
-}
-
-# Only ever matches the lines this script writes, so an entry a user added by
-# hand for the same host is left alone on removal.
-host_pattern() {
-  echo "^0\.0\.0\.0[[:space:]][[:space:]]*$(echo "$1" | sed 's/\./\\./g')\$"
-}
-
-hosts_block() {
-  local host
-  hosts_end_with_newline
-  grep -q "^${MARKER}\$" "$HOSTS" 2>/dev/null || printf '%s\n' "$MARKER" >> "$HOSTS"
-  for host in $BLACKHOLE; do
-    grep -q "$(host_pattern "$host")" "$HOSTS" 2>/dev/null || printf '0.0.0.0 %s\n' "$host" >> "$HOSTS"
-  done
-}
-
-hosts_unblock() {
-  local host
-  [ -f "$HOSTS" ] || return 0
-  for host in $BLACKHOLE; do
-    sed -i "/$(host_pattern "$host")/d" "$HOSTS"
-  done
-  sed -i "/^${MARKER}\$/d" "$HOSTS"
-}
-
-# At boot this can run before DHCP has finished, which would add the drops with
-# no LAN exemption and leave a local MQTT broker unreachable until the next
+# At boot this can run before DHCP has finished, which would build the chain
+# with no LAN exemption and leave a local MQTT broker unreachable until the next
 # boot. Wait briefly, but never hold up a printer that has no network at all.
 wait_for_lan() {
   local waited=0
-  while [ -z "$(lan_networks)" ] && [ "$waited" -lt 5 ]; do
+  while [ -z "$(lan_networks)" ] && [ "$waited" -lt "$LAN_WAIT_SECONDS" ]; do
     sleep 1
     waited=$((waited + 1))
   done
 }
 
+# Everything outside the managed region, verbatim. A begin marker with no end
+# marker deletes to EOF, which is the right recovery from an interrupted write.
+hosts_without_block() {
+  [ -f "$HOSTS" ] || return 0
+  sed "/^${BEGIN_MARKER}\$/,/^${END_MARKER}\$/d" "$HOSTS"
+}
+
+# Rewritten in a single pass rather than appended line by line, so there is one
+# window in which a concurrent writer could be clobbered instead of seventeen.
+# Copied back with cat rather than mv to keep the original inode, mode and owner
+# and to leave a symlinked /etc/hosts pointing where it did before.
+hosts_write() {
+  local host
+  local last
+  local tmp="${HOSTS}.cloudblock.$$"
+  hosts_without_block > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 1; }
+  if [ "$1" = "block" ]; then
+    # sed preserves a missing final newline, so without this the begin marker
+    # would be appended onto the end of the last existing line. That corrupts
+    # the line and, worse, hides the marker from the range delete on uninstall,
+    # stranding the whole block. Fails closed: if tail -c is unavailable the
+    # newline goes in anyway, because a blank line is harmless and a joined line
+    # is not.
+    if [ -s "$tmp" ]; then
+      last=$(tail -c 1 "$tmp" 2>/dev/null) || last="x"
+      [ -z "$last" ] || printf '\n' >> "$tmp"
+    fi
+    {
+      printf '%s\n' "$BEGIN_MARKER"
+      for host in $BLACKHOLE; do
+        printf '0.0.0.0 %s\n' "$host"
+      done
+      printf '%s\n' "$END_MARKER"
+    } >> "$tmp" || { rm -f "$tmp"; return 1; }
+  fi
+  cat "$tmp" > "$HOSTS" || { rm -f "$tmp"; return 1; }
+  rm -f "$tmp"
+}
+
+# Rebuilt from scratch on every start, so a changed LAN, a hand-edited entry or
+# a host list that grew between versions all self-heal instead of accumulating.
 mqtt_block() {
   local lan
   local port
-  have_iptables || return 0
+  local rc=0
+
+  probe_iptables
+  case "$IPTABLES_STATE" in
+    absent)
+      return 0
+      ;;
+    error)
+      echo "Warning: iptables is present but unusable, MQTT port rules skipped." >&2
+      return 1
+      ;;
+  esac
+
   wait_for_lan
+
+  ipt -N "$CHAIN" 2>/dev/null
+  ipt -F "$CHAIN" || rc=1
+
   for port in $MQTT_PORTS; do
-    # 127.0.0.1 is not in the LAN CIDR, and a blackholed host resolves to
-    # 0.0.0.0, which the kernel routes to loopback. Without this the drop below
-    # silently swallows that traffic instead of letting it fail fast with a
-    # RST. Every rule is scoped to an MQTT port so that removing it can never
-    # take out a broader rule another tool owns.
-    accept_rule OUTPUT -o lo -p tcp --dport "$port" -j ACCEPT
+    # A blackholed host resolves to 0.0.0.0, which the kernel routes to
+    # loopback. Without this the drop below swallows that silently instead of
+    # letting it fail fast with a RST.
+    ipt -A "$CHAIN" -o lo -p tcp --dport "$port" -j ACCEPT || rc=1
     for lan in $(lan_networks); do
-      accept_rule OUTPUT -p tcp -d "$lan" --dport "$port" -j ACCEPT
+      ipt -A "$CHAIN" -p tcp -d "$lan" --dport "$port" -j ACCEPT || rc=1
     done
     # vectorp carries hardcoded broker IPs (47.114.48.45:1883 and
     # 120.55.101.240:1883) that bypass DNS entirely, so the port rules are what
     # actually stops it.
-    drop_rule OUTPUT -p tcp --dport "$port" -j DROP
+    ipt -A "$CHAIN" -p tcp --dport "$port" -j DROP || rc=1
   done
+
+  # Inserted, not appended: an OUTPUT chain that already carries a broad ACCEPT
+  # would otherwise match first and the drops would never be reached.
+  chain_is_linked || ipt -I OUTPUT -j "$CHAIN" || rc=1
+
+  [ "$rc" -eq 0 ] || echo "Warning: some MQTT port rules could not be applied." >&2
+  return "$rc"
 }
 
 mqtt_unblock() {
-  local lan
-  local port
-  have_iptables || return 0
-  for port in $MQTT_PORTS; do
-    delete_rule OUTPUT -p tcp --dport "$port" -j DROP
-    for lan in $(lan_networks); do
-      delete_rule OUTPUT -p tcp -d "$lan" --dport "$port" -j ACCEPT
-    done
-    delete_rule OUTPUT -o lo -p tcp --dport "$port" -j ACCEPT
+  probe_iptables
+  [ "$IPTABLES_STATE" = "ok" ] || return 0
+
+  while chain_is_linked; do
+    ipt -D OUTPUT -j "$CHAIN" 2>/dev/null || break
   done
+  ipt -F "$CHAIN" 2>/dev/null
+  ipt -X "$CHAIN" 2>/dev/null
+  return 0
 }
+
+rc=0
 
 case "$1" in
   start)
     echo "Blocking Creality cloud telemetry..."
-    hosts_block
-    mqtt_block
+    hosts_write block || { echo "Error: could not update $HOSTS." >&2; rc=1; }
+    mqtt_block || rc=1
     ;;
   stop)
     echo "Unblocking Creality cloud telemetry..."
     mqtt_unblock
-    hosts_unblock
+    hosts_write unblock || { echo "Error: could not restore $HOSTS." >&2; rc=1; }
     ;;
   restart|force-reload)
     "$0" stop
     "$0" start
+    rc=$?
     ;;
   status)
-    blocked=0
-    total=0
-    for host in $BLACKHOLE; do
-      total=$((total + 1))
-      if grep -q "$(host_pattern "$host")" "$HOSTS" 2>/dev/null; then
-        blocked=$((blocked + 1))
-      fi
-    done
-    echo "Hosts blocklist: $blocked of $total entries present"
-    if have_iptables; then
-      iptables -L OUTPUT -v -n
+    if grep -q "^${BEGIN_MARKER}\$" "$HOSTS" 2>/dev/null; then
+      echo "Hosts blocklist: active ($(sed -n "/^${BEGIN_MARKER}\$/,/^${END_MARKER}\$/p" "$HOSTS" | grep -c '^0\.0\.0\.0') entries)"
     else
-      echo "MQTT port rules: skipped (iptables not available)"
+      echo "Hosts blocklist: inactive"
     fi
+    probe_iptables
+    case "$IPTABLES_STATE" in
+      absent)
+        echo "MQTT port rules: skipped (no iptables on this model)"
+        ;;
+      error)
+        echo "MQTT port rules: iptables is present but unusable"
+        rc=1
+        ;;
+      ok)
+        if chain_is_linked; then
+          ipt -L "$CHAIN" -v -n
+        else
+          echo "MQTT port rules: chain $CHAIN is not linked into OUTPUT"
+        fi
+        ;;
+    esac
     ;;
   *)
     echo "Usage: $0 {start|stop|restart|force-reload|status}"
     exit 1
+    ;;
 esac
 
-exit 0
+exit "$rc"

--- a/scripts/block_creality_cloud.sh
+++ b/scripts/block_creality_cloud.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+set -e
+
+function block_creality_cloud_message(){
+  top_line
+  title 'Block Creality Cloud Telemetry' "${yellow}"
+  inner_line
+  hr
+  echo -e " │ ${cyan}This allows to blackhole the Creality cloud hosts used by    ${white}│"
+  echo -e " │ ${cyan}stock daemons for telemetry, remote access and OTA checks,   ${white}│"
+  echo -e " │ ${cyan}and to drop outbound MQTT to anything outside your network.  ${white}│"
+  hr
+  echo -e " │ ${cyan}Remote access options (OctoEverywhere, Obico, GuppyFLO,      ${white}│"
+  echo -e " │ ${cyan}SimplyPrint, OctoApp, Mobileraker) are not affected.         ${white}│"
+  hr
+  bottom_line
+}
+
+function install_block_creality_cloud(){
+  block_creality_cloud_message
+  local yn
+  while true; do
+    install_msg "Block Creality Cloud Telemetry" yn
+    case "${yn}" in
+      Y|y)
+        echo -e "${white}"
+        echo -e "Info: Copying service file..."
+        cp "$CLOUD_BLOCK_SERVICE_URL" "$CLOUD_BLOCK_SERVICE_FILE"
+        chmod 755 "$CLOUD_BLOCK_SERVICE_FILE"
+        echo -e "Info: Applying blocklist..."
+        set +e
+        "$CLOUD_BLOCK_SERVICE_FILE" start
+        set -e
+        ok_msg "Block Creality Cloud Telemetry has been installed successfully!"
+        if ! command -v iptables > /dev/null 2>&1; then
+          echo -e " ${darkred}Note: iptables is not available on this printer, MQTT port rules were skipped.${white}"
+          echo -e " ${darkred}The hosts blocklist is still active.${white}"
+          echo
+        fi
+        echo -e " ${white}Connections already open are not torn down, reboot to apply it fully.${white}"
+        echo
+        return;;
+      N|n)
+        error_msg "Installation canceled!"
+        return;;
+      *)
+        error_msg "Please select a correct choice!";;
+    esac
+  done
+}
+
+function remove_block_creality_cloud(){
+  block_creality_cloud_message
+  local yn
+  while true; do
+    remove_msg "Block Creality Cloud Telemetry" yn
+    case "${yn}" in
+      Y|y)
+        echo -e "${white}"
+        echo -e "Info: Restoring hosts file and removing rules..."
+        set +e
+        if [ -f "$CLOUD_BLOCK_SERVICE_FILE" ]; then
+          "$CLOUD_BLOCK_SERVICE_FILE" stop
+        fi
+        set -e
+        echo -e "Info: Removing file..."
+        rm -f "$CLOUD_BLOCK_SERVICE_FILE"
+        ok_msg "Block Creality Cloud Telemetry has been removed successfully!"
+        return;;
+      N|n)
+        error_msg "Deletion canceled!"
+        return;;
+      *)
+        error_msg "Please select a correct choice!";;
+    esac
+  done
+}

--- a/scripts/block_creality_cloud.sh
+++ b/scripts/block_creality_cloud.sh
@@ -29,12 +29,20 @@ function install_block_creality_cloud(){
         cp "$CLOUD_BLOCK_SERVICE_URL" "$CLOUD_BLOCK_SERVICE_FILE"
         chmod 755 "$CLOUD_BLOCK_SERVICE_FILE"
         echo -e "Info: Applying blocklist..."
+        local start_rc
         set +e
         "$CLOUD_BLOCK_SERVICE_FILE" start
+        start_rc=$?
         set -e
+        if [ "$start_rc" -ne 0 ]; then
+          error_msg "Block Creality Cloud Telemetry was installed but did not apply cleanly!"
+          echo -e " ${darkred}Run '$CLOUD_BLOCK_SERVICE_FILE status' to see what is missing.${white}"
+          echo
+          return
+        fi
         ok_msg "Block Creality Cloud Telemetry has been installed successfully!"
         if ! command -v iptables > /dev/null 2>&1; then
-          echo -e " ${darkred}Note: iptables is not available on this printer, MQTT port rules were skipped.${white}"
+          echo -e " ${darkred}Note: this printer has no iptables, so the MQTT port rules were skipped.${white}"
           echo -e " ${darkred}The hosts blocklist is still active.${white}"
           echo
         fi

--- a/scripts/menu/10SE/customize_menu_10SE.sh
+++ b/scripts/menu/10SE/customize_menu_10SE.sh
@@ -15,6 +15,9 @@ function customize_menu_ui_10se() {
   hr
   menu_option '5' 'Install' 'Creality Dynamic Logos for Fluidd'
   hr
+  menu_option '6' 'Install' 'Block Creality Cloud Telemetry'
+  menu_option '7' 'Remove' 'Block Creality Cloud Telemetry'
+  hr
   inner_line
   hr
   bottom_menu_option 'b' 'Back to [Main Menu]' "${yellow}"
@@ -78,6 +81,18 @@ function customize_menu_10se() {
           error_msg "Fluidd is needed, please install it first!"
         else
           run "install_creality_dynamic_logos" "customize_menu_ui_10se"
+        fi;;
+      6)
+        if [ -f "$CLOUD_BLOCK_SERVICE_FILE" ]; then
+          error_msg "Block Creality Cloud Telemetry is already installed!"
+        else
+          run "install_block_creality_cloud" "customize_menu_ui_10se"
+        fi;;
+      7)
+        if [ ! -f "$CLOUD_BLOCK_SERVICE_FILE" ]; then
+          error_msg "Block Creality Cloud Telemetry is not installed!"
+        else
+          run "remove_block_creality_cloud" "customize_menu_ui_10se"
         fi;;
       B|b)
         clear; main_menu; break;;

--- a/scripts/menu/10SE/info_menu_10SE.sh
+++ b/scripts/menu/10SE/info_menu_10SE.sh
@@ -66,6 +66,7 @@ function info_menu_ui_10se() {
   info_line "$(check_file_10se "$CREALITY_WEB_FILE")" 'Creality Web Interface'
   info_line "$(check_folder_10se "$GUPPY_SCREEN_FOLDER")" 'Guppy Screen'
   info_line "$(check_file_10se "$FLUIDD_LOGO_FILE")" 'Creality Dynamic Logos for Fluidd'
+  info_line "$(check_file_10se "$CLOUD_BLOCK_SERVICE_FILE")" 'Block Creality Cloud Telemetry'
   hr
   inner_line
   hr

--- a/scripts/menu/3KE/customize_menu_3KE.sh
+++ b/scripts/menu/3KE/customize_menu_3KE.sh
@@ -15,6 +15,9 @@ function customize_menu_ui_3ke() {
   hr
   menu_option '5' 'Install' 'Creality Dynamic Logos for Fluidd'
   hr
+  menu_option '6' 'Install' 'Block Creality Cloud Telemetry'
+  menu_option '7' 'Remove' 'Block Creality Cloud Telemetry'
+  hr
   inner_line
   hr
   bottom_menu_option 'b' 'Back to [Main Menu]' "${yellow}"
@@ -78,6 +81,18 @@ function customize_menu_3ke() {
           error_msg "Fluidd is needed, please install it first!"
         else
           run "install_creality_dynamic_logos" "customize_menu_ui_3ke"
+        fi;;
+      6)
+        if [ -f "$CLOUD_BLOCK_SERVICE_FILE" ]; then
+          error_msg "Block Creality Cloud Telemetry is already installed!"
+        else
+          run "install_block_creality_cloud" "customize_menu_ui_3ke"
+        fi;;
+      7)
+        if [ ! -f "$CLOUD_BLOCK_SERVICE_FILE" ]; then
+          error_msg "Block Creality Cloud Telemetry is not installed!"
+        else
+          run "remove_block_creality_cloud" "customize_menu_ui_3ke"
         fi;;
       B|b)
         clear; main_menu; break;;

--- a/scripts/menu/3KE/info_menu_3KE.sh
+++ b/scripts/menu/3KE/info_menu_3KE.sh
@@ -68,6 +68,7 @@ function info_menu_ui_3ke() {
   info_line "$(check_file_3ke "$CREALITY_WEB_FILE")" 'Creality Web Interface'
   info_line "$(check_folder_3ke "$GUPPY_SCREEN_FOLDER")" 'Guppy Screen'
   info_line "$(check_file_3ke "$FLUIDD_LOGO_FILE")" 'Creality Dynamic Logos for Fluidd'
+  info_line "$(check_file_3ke "$CLOUD_BLOCK_SERVICE_FILE")" 'Block Creality Cloud Telemetry'
   hr
   inner_line
   hr

--- a/scripts/menu/3V3/customize_menu_3V3.sh
+++ b/scripts/menu/3V3/customize_menu_3V3.sh
@@ -15,6 +15,9 @@ function customize_menu_ui_3v3() {
   hr
   menu_option '5' 'Install' 'Creality Dynamic Logos for Fluidd'
   hr
+  menu_option '6' 'Install' 'Block Creality Cloud Telemetry'
+  menu_option '7' 'Remove' 'Block Creality Cloud Telemetry'
+  hr
   inner_line
   hr
   bottom_menu_option 'b' 'Back to [Main Menu]' "${yellow}"
@@ -78,6 +81,18 @@ function customize_menu_3v3() {
           error_msg "Updated Fluidd is needed, please install it first!"
         else
           run "install_creality_dynamic_logos" "customize_menu_ui_3v3"
+        fi;;
+      6)
+        if [ -f "$CLOUD_BLOCK_SERVICE_FILE" ]; then
+          error_msg "Block Creality Cloud Telemetry is already installed!"
+        else
+          run "install_block_creality_cloud" "customize_menu_ui_3v3"
+        fi;;
+      7)
+        if [ ! -f "$CLOUD_BLOCK_SERVICE_FILE" ]; then
+          error_msg "Block Creality Cloud Telemetry is not installed!"
+        else
+          run "remove_block_creality_cloud" "customize_menu_ui_3v3"
         fi;;
       B|b)
         clear; main_menu; break;;

--- a/scripts/menu/3V3/info_menu_3V3.sh
+++ b/scripts/menu/3V3/info_menu_3V3.sh
@@ -70,6 +70,7 @@ function info_menu_ui_3v3() {
   info_line "$(check_file_3v3 "$CREALITY_WEB_FILE")" 'Creality Web Interface'
   info_line "$(check_folder_3v3 "$GUPPY_SCREEN_FOLDER")" 'Guppy Screen'
   info_line "$(check_file_3v3 "$FLUIDD_LOGO_FILE")" 'Creality Dynamic Logos for Fluidd'
+  info_line "$(check_file_3v3 "$CLOUD_BLOCK_SERVICE_FILE")" 'Block Creality Cloud Telemetry'
   hr
   inner_line
   hr

--- a/scripts/menu/E5M/customize_menu_E5M.sh
+++ b/scripts/menu/E5M/customize_menu_E5M.sh
@@ -15,6 +15,9 @@ function customize_menu_ui_e5m() {
   hr
   menu_option '5' 'Install' 'Creality Dynamic Logos for Fluidd'
   hr
+  menu_option '6' 'Install' 'Block Creality Cloud Telemetry'
+  menu_option '7' 'Remove' 'Block Creality Cloud Telemetry'
+  hr
   inner_line
   hr
   bottom_menu_option 'b' 'Back to [Main Menu]' "${yellow}"
@@ -78,6 +81,18 @@ function customize_menu_e5m() {
           error_msg "Fluidd is needed, please install it first!"
         else
           run "install_creality_dynamic_logos" "customize_menu_ui_e5m"
+        fi;;
+      6)
+        if [ -f "$CLOUD_BLOCK_SERVICE_FILE" ]; then
+          error_msg "Block Creality Cloud Telemetry is already installed!"
+        else
+          run "install_block_creality_cloud" "customize_menu_ui_e5m"
+        fi;;
+      7)
+        if [ ! -f "$CLOUD_BLOCK_SERVICE_FILE" ]; then
+          error_msg "Block Creality Cloud Telemetry is not installed!"
+        else
+          run "remove_block_creality_cloud" "customize_menu_ui_e5m"
         fi;;
       B|b)
         clear; main_menu; break;;

--- a/scripts/menu/E5M/info_menu_E5M.sh
+++ b/scripts/menu/E5M/info_menu_E5M.sh
@@ -74,6 +74,7 @@ function info_menu_ui_e5m() {
   info_line "$(check_file_e5m "$CREALITY_WEB_FILE")" 'Creality Web Interface'
   info_line "$(check_folder_e5m "$GUPPY_SCREEN_FOLDER")" 'Guppy Screen'
   info_line "$(check_file_e5m "$FLUIDD_LOGO_FILE")" 'Creality Dynamic Logos for Fluidd'
+  info_line "$(check_file_e5m "$CLOUD_BLOCK_SERVICE_FILE")" 'Block Creality Cloud Telemetry'
   hr
   inner_line
   hr

--- a/scripts/menu/K1/customize_menu_K1.sh
+++ b/scripts/menu/K1/customize_menu_K1.sh
@@ -18,6 +18,9 @@ function customize_menu_ui_k1() {
   hr
   menu_option '7' 'Install' 'Creality Dynamic Logos for Fluidd'
   hr
+  menu_option '8' 'Install' 'Block Creality Cloud Telemetry'
+  menu_option '9' 'Remove' 'Block Creality Cloud Telemetry'
+  hr
   inner_line
   hr
   bottom_menu_option 'b' 'Back to [Main Menu]' "${yellow}"
@@ -97,6 +100,18 @@ function customize_menu_k1() {
           error_msg "Fluidd is needed, please install it first!"
         else
           run "install_creality_dynamic_logos" "customize_menu_ui_k1"
+        fi;;
+      8)
+        if [ -f "$CLOUD_BLOCK_SERVICE_FILE" ]; then
+          error_msg "Block Creality Cloud Telemetry is already installed!"
+        else
+          run "install_block_creality_cloud" "customize_menu_ui_k1"
+        fi;;
+      9)
+        if [ ! -f "$CLOUD_BLOCK_SERVICE_FILE" ]; then
+          error_msg "Block Creality Cloud Telemetry is not installed!"
+        else
+          run "remove_block_creality_cloud" "customize_menu_ui_k1"
         fi;;
       B|b)
         clear; main_menu; break;;

--- a/scripts/menu/K1/info_menu_K1.sh
+++ b/scripts/menu/K1/info_menu_K1.sh
@@ -74,6 +74,7 @@ function info_menu_ui_k1() {
   info_line "$(check_file_k1 "$CREALITY_WEB_FILE")" 'Creality Web Interface'
   info_line "$(check_folder_k1 "$GUPPY_SCREEN_FOLDER")" 'Guppy Screen'
   info_line "$(check_file_k1 "$FLUIDD_LOGO_FILE")" 'Creality Dynamic Logos for Fluidd'
+  info_line "$(check_file_k1 "$CLOUD_BLOCK_SERVICE_FILE")" 'Block Creality Cloud Telemetry'
   hr
   inner_line
   hr

--- a/scripts/menu/K1_2025/customize_menu_K1C_2025.sh
+++ b/scripts/menu/K1_2025/customize_menu_K1C_2025.sh
@@ -9,6 +9,9 @@ function customize_menu_ui_k1_2025() {
   hr
   menu_option '1' 'Install' 'Creality Dynamic Logos for Fluidd'
   hr
+  menu_option '2' 'Install' 'Block Creality Cloud Telemetry'
+  menu_option '3' 'Remove' 'Block Creality Cloud Telemetry'
+  hr
   inner_line
   hr
   bottom_menu_option 'b' 'Back to [Main Menu]' "${yellow}"
@@ -32,6 +35,18 @@ function customize_menu_k1_2025() {
           error_msg "Fluidd is needed, please install it first!"
         else
           run "install_creality_dynamic_logos" "customize_menu_ui_k1_2025"
+        fi;;
+      2)
+        if [ -f "$CLOUD_BLOCK_SERVICE_FILE" ]; then
+          error_msg "Block Creality Cloud Telemetry is already installed!"
+        else
+          run "install_block_creality_cloud" "customize_menu_ui_k1_2025"
+        fi;;
+      3)
+        if [ ! -f "$CLOUD_BLOCK_SERVICE_FILE" ]; then
+          error_msg "Block Creality Cloud Telemetry is not installed!"
+        else
+          run "remove_block_creality_cloud" "customize_menu_ui_k1_2025"
         fi;;
       B|b)
         clear; main_menu; break;;

--- a/scripts/menu/K1_2025/info_menu_K1C_2025.sh
+++ b/scripts/menu/K1_2025/info_menu_K1C_2025.sh
@@ -84,6 +84,7 @@ function info_menu_ui_k1_2025() {
   hr
   subtitle '•CUSTOMIZATION:'
   info_line "$(check_file_k1_2025 "$FLUIDD_LOGO_FILE")" 'Creality Dynamic Logos for Fluidd'
+  info_line "$(check_file_k1_2025 "$CLOUD_BLOCK_SERVICE_FILE")" 'Block Creality Cloud Telemetry'
   hr
   inner_line
   hr

--- a/scripts/paths.sh
+++ b/scripts/paths.sh
@@ -222,6 +222,10 @@ function set_paths() {
   GO2RTC_CONFIG_FILE_URL="${HS_FILES}/go2rtc/go2rtc.yaml"
   GO2RTC_SERVICE_URL="${HS_FILES}/services/S50go2rtc"
   GO2RTC_SERVICE_FILE="${INITD_FOLDER}/S50go2rtc"
+
+  # Block Creality Cloud Telemetry #
+  CLOUD_BLOCK_SERVICE_URL="${HS_FILES}/services/S995cloudblock"
+  CLOUD_BLOCK_SERVICE_FILE="${INITD_FOLDER}/S995cloudblock"
 }
 
 function set_permissions() {


### PR DESCRIPTION
Creality's stock telemetry agent uploads printer configs and Klipper logs to `*.cxswyjy.com`, a domain the `crealitycloud.com`-only blocklists in circulation do not cover at all. This adds a Customize menu option that blackholes the 16 known Creality cloud hosts and drops outbound MQTT to anything off the LAN.

The agent is `alchemistp` (init script `CS61alchemistp_service`), whose config at `/etc/appetc/alchemistp/config.json` declares `UploadFileFlag: 1` over `/usr/data/printer_data/config/*` and `/usr/data/printer_data/logs/*`, pointed at `c-smart.cxswyjy.com` and `devdata.cxswyjy.com`. It has already uploaded: `upload_file_offset.json` on a stock machine lists `printer.cfg`, `klippy.log` and the per-daemon logs as having gone out. Captured on the wire mid-print on a K1C 2025, with a five-host `.com` blocklist already active:

```
14:24:22.489618 IP 192.168.0.76.34009 > 1.1.1.1.53: A? devdata.cxswyjy.com.
14:24:22.538055 IP 1.1.1.1.53 > 192.168.0.76.34009:
                CNAME devdata-1343527910.us-east-1.elb.amazonaws.com., A 98.86.129.225
14:24:22.539063 IP 192.168.0.76.48120 > 98.86.129.225.443: Flags [S]
14:24:22.743789 IP 98.86.129.225.443 > 192.168.0.76.48120: Flags [S.]
```

That SYN-ACK is a real AWS load balancer answering, and `/proc/net/tcp` showed the socket established a minute later. Separately, `onyxp` beacons SN and MAC to the `.cn` signalling hosts once per boot and got a live `{"code":4,"errMsg":"Invalid Token"}` reply, which likewise means a server answered rather than a blackhole.

The option installs the hosts entries and an init script at `$INITD_FOLDER/S995cloudblock`. The boot script is not optional bookkeeping: on the K1 2025 the rootfs is a volatile RAM filesystem, so `/etc/hosts` reverts to stock on every boot, and iptables rules never survive a reboot on any model.

Everything the script writes is explicitly owned rather than identified by matching content, because content matching means uninstall removes state it never created. The hosts entries live between `# BEGIN` and `# END` markers and are removed as a range, so a user who had already blackholed one of these hosts by hand keeps their line. The firewall rules live in a `CREALITY_CLOUDBLOCK` chain that uninstall flushes and deletes, so an identical MQTT rule belonging to another tool survives, and removal does not need to know which LAN was attached at install time. Both are rebuilt from scratch on every start, so a changed subnet, a hand-edited entry, or a host list that grew between versions self-heal instead of accumulating.

Two details are worth calling out because the obvious implementation gets them wrong. Loopback needs an explicit exemption ahead of the MQTT drops: with the hosts blackhole active a daemon resolves `mqtt.crealitycloud.com` to `0.0.0.0`, the kernel routes that connect to `127.0.0.1:1883`, and a plain `--dport 1883 -j DROP` swallows it silently instead of letting it fail fast with a RST. And the chain is linked into OUTPUT with an insert rather than an append, because an OUTPUT chain that already carries a broad ACCEPT would otherwise match first and the drops would never be reached. The LAN is detected from `ip route` rather than hardcoded, keyed on `src` plus a CIDR rather than on `proto kernel` which not every `ip` implementation prints, and the exemption is skipped entirely when detection turns up nothing, because a wrong CIDR on a headless printer is undebuggable remotely.

Failures are not swallowed. iptables calls take `-w` where the build supports it and fall back where it does not, a present-but-unusable iptables is distinguished from a model that simply has none, and `start` returns non-zero so the installer reports a partial apply instead of printing success over it.

Per-model behaviour is gated on capability, not assumption. The K1 and Ender-3 V3 series ship without an iptables binary even though the kernel module is loaded, so the port rules are skipped there and the install says so; the hosts blocklist still applies. `INITD_FOLDER` from `paths.sh` handles the `/usr/apps/etc/init.d` versus `/etc/init.d` split, and on the 2025 that path is what `/bin/seed.sh` walks for `S??*` at boot.

This is a blocklist, not a firewall. The OUTPUT policy is left untouched and nothing else is filtered, so OctoEverywhere, Obico, GuppyFLO, SimplyPrint, OctoApp and Mobileraker are unaffected.

## Test plan

- [x] `sh -n` parses the new boot script, the new option, `paths.sh`, and all twelve touched menu files
- [x] Boot script exercised under `dash` against a stateful fake `iptables` (custom chains included) and a fake `ip route`: 16 entries applied, idempotent across repeated starts, the chain linked once and first in OUTPUT, and after uninstall no rules, no chain, and no residue
- [x] Ownership cases: a user's own `0.0.0.0` entry for a blocked host survives uninstall, another tool's identical `--dport 1883 -j DROP` and broad `-o lo -j ACCEPT` are left untouched, and a hand-edited managed line heals on the next start rather than duplicating
- [x] Degradation cases: no iptables at all, iptables present but rejecting `-w`, no route detected, and a subnet change between install and uninstall all behave correctly and leave nothing behind
- [x] `/etc/hosts` restored byte-for-byte on a newline-terminated file; on a file with no trailing newline it comes back with one synthesised newline added and is otherwise identical
- [x] Verified directly on a K1C 2025 and a K1C running the OverlayFS firmware: the exact `sed` range delete and its unterminated-block recovery, `local` in ash, `tail -c`, the `ip route` parse, `iptables -w` and `-C` support on the 2025 and the total absence of iptables on the OG, `/etc/hosts` being a regular file on both, and that `rcK` calls `stop` at shutdown
- [x] Menu rows, message box and Information line rendered locally; alignment matches the existing options
- [ ] Manual test pass (see checklist below)

The shell-level checks above use fakes for `iptables` and `ip route`, so they verify the logic rather than the live effect. Nothing has been installed on a printer, no reboot persistence test has been run, and the per-model gating is reasoned rather than observed on four of the six models. The manual pass below is the one that matters and has not been done.

## Manual test pass

- [ ] Install through the Customize menu on a K1 2025; expect 16 entries between the markers in `/etc/hosts` and an executable `S995cloudblock` in `$INITD_FOLDER`
- [ ] `nslookup devdata.cxswyjy.com`; expect `0.0.0.0`
- [ ] `S995cloudblock status`; expect 16 entries reported and the chain listed with the loopback and LAN ACCEPT rules above both drops
- [ ] `iptables -L OUTPUT -v -n`; expect the jump to `CREALITY_CLOUDBLOCK`, and the 1883 drop counter not climbing steadily (steady growth means the loopback exemption is wrong)
- [ ] Reboot; expect both the hosts entries and the chain to come back on their own
- [ ] Uninstall; expect `/etc/hosts` identical to stock, no `CREALITY_CLOUDBLOCK` chain, and the init script gone
- [ ] Confirm a print completes and Fluidd, Moonraker and the webcam are unaffected
- [ ] Install and uninstall on a K1 or Ender-3 V3; expect the skipped-port-rules notice and a clean hosts restore

## Not addressed

`/etc/hosts` cannot express wildcards, so any other subdomain of `cxswyjy.com` or `crealitycloud.cn` stays reachable, and a hardcoded IP bypasses the hosts file entirely. The port rules cover the hardcoded MQTT brokers in `vectorp` (`47.114.48.45:1883` and `120.55.101.240:1883`), but the wildcard gap is real. Closing it properly needs a default-deny egress firewall, which breaks every cloud relay option this helper ships, so that UX problem should be solved before such a thing is offered to anyone.

The LAN wait at boot is capped at five seconds. If DHCP takes longer than that on a cold wifi association, the chain is built without a LAN exemption and a local MQTT broker stays unreachable until the next start. Raising the cap would delay boot on a printer with no network at all, and a background retry felt like more machinery than this warrants, so the bound stays fixed and visible as `LAN_WAIT_SECONDS`.

Remove is gated on the init script existing. If someone deletes `$INITD_FOLDER/S995cloudblock` by hand, the hosts entries and the chain stay live with no menu path to clear them; recovery is to install again and then remove. On the K1 2025 a reboot clears both anyway, since the rootfs and the ruleset are volatile.

Disabling the stock daemons outright is deliberately separate. The two are complementary rather than alternatives: disabling removes the processes that want to talk, blocking removes the ability, and the block is what still protects a user after a firmware OTA or a helper reinstall puts the daemons back.

IPv6 is not filtered. The 2025 has no IPv6 address and no v6 default route, so v6 egress is currently impossible, and its kernel has no ip6 `filter` table at all, so if SLAAC were ever enabled there would be no way to filter it.

The single stale broker IP `47.253.214.226` that older blocklist scripts pin is deliberately not included. It appears in none of the seven stock binaries; it was a runtime DNS answer for `mqtt.crealitycloud.com` on one particular day and pinning it achieves nothing the hosts entry does not.
