### PR TITLE
Gate the camera package check on the model, and migrate printers off the retired Entware feed host

### DIFF
--- a/helper.sh
+++ b/helper.sh
@@ -111,5 +111,8 @@ if [ -z "$model" ] && [ "$model" != "K1_2025" ] && [ ! -f $INITD_FOLDER/S58facto
 fi
 
 set_permissions
+# Repairs an existing /opt/etc/opkg.conf still pointing at the retired feed
+# host. Must not be able to fail the script -- this is the recovery tool.
+migrate_entware_feed_host || true
 update_menu
 main_menu

--- a/scripts/entware.sh
+++ b/scripts/entware.sh
@@ -64,6 +64,63 @@ function k1_2025_migrate_entware_boot_if_needed() {
   k1_2025_write_entware_init_script
 }
 
+# The installer runs with errexit disabled, so nothing below it notices a
+# failure. Check that it produced the two things the rest of the script depends
+# on, and report the first problem found rather than claiming success.
+function verify_entware_install(){
+  if [ ! -f /opt/libexec/sftp-server ]; then
+    error_msg "Entware install did not complete: openssh-sftp-server is missing, SFTP will not work."
+    return 1
+  fi
+  if [ ! -s /opt/etc/opkg.conf ]; then
+    error_msg "Entware install did not complete: /opt/etc/opkg.conf is missing or empty."
+    return 1
+  fi
+  if ! grep -q '^src/gz ' /opt/etc/opkg.conf; then
+    error_msg "Entware install did not complete: /opt/etc/opkg.conf has no package feed."
+    return 1
+  fi
+  return 0
+}
+
+# /opt/etc/opkg.conf lives on the printer's persistent /opt, which no helper
+# script update touches, so printers set up before the feed moved still point at
+# bin.tranducanh.com. That host stopped serving the repository. Repair it in
+# place, matching on the hostname so any feed lines the user added survive.
+function migrate_entware_feed_host(){
+  local conf="/opt/etc/opkg.conf"
+  local tmp
+
+  # On K1 2025 /opt is a loop mount that only S48entware creates; helper.sh
+  # never mounts it, so an unmounted /opt means there is nothing to migrate.
+  if [ "$model" = "K1_2025" ] && ! grep -q " /opt " /proc/mounts 2>/dev/null; then
+    return 0
+  fi
+  [ -f "$conf" ] || return 0
+  grep -q 'bin\.tranducanh\.com' "$conf" || return 0
+
+  # /opt is a fixed-size image and can be full. Build the replacement beside the
+  # original and only swap it in once it is known to be complete -- "sed -i"
+  # would leave a truncated or empty config behind.
+  tmp="${conf}.new.$$"
+  if ! sed 's|bin\.tranducanh\.com|bin.entware.net|g' "$conf" > "$tmp" \
+     || [ ! -s "$tmp" ] \
+     || [ "$(wc -l < "$tmp")" -ne "$(wc -l < "$conf")" ] \
+     || ! mv "$tmp" "$conf"; then
+    rm -f "$tmp"
+    return 1
+  fi
+
+  echo -e "${white}"
+  echo -e " ${green}Entware package feed moved to bin.entware.net (bin.tranducanh.com is gone).${white}"
+  echo -e " Run ${yellow}opkg update${white} before installing packages, so the package list is refreshed too."
+  echo
+  # main_menu clears the screen, so pause once to let the notice be read. Never
+  # let the prompt itself decide the outcome of a migration that succeeded.
+  read -p " Press Enter to continue... " _ || true
+  return 0
+}
+
 function install_entware(){
   entware_message
   local yn
@@ -78,20 +135,24 @@ function install_entware(){
           k1_2025_opt_mount
           $HS_FILES/fixes/curl -L "https://bin.entware.net/mipselsf-k3.4/installer/generic.sh" | sh
           export PATH=/opt/bin:/opt/sbin:$PATH
-          # I'm not sure why we were using Tranducanh.com. It got wiped and it broke everything. It makes more sense to just use the official one.
-          sed -i '1s|.*|src/gz entware http://bin.entware.net/mipselsf-k3.4|' /opt/etc/opkg.conf
           opkg update
 
           opkg install openssh-sftp-server
-          # Symlink also created on boot by S48entware
-          ln -sf /opt/libexec/sftp-server /usr/libexec/sftp-server
+          # Same guard as the S48entware boot script, which also creates this
+          # symlink: never point it at a file the install failed to produce.
+          mkdir -p /usr/libexec
+          if [ ! -e /usr/libexec/sftp-server ] && [ -f /opt/libexec/sftp-server ]; then
+            ln -sf /opt/libexec/sftp-server /usr/libexec/sftp-server
+          fi
         else
-          prepare_opt
           chmod 755 "$ENTWARE_URL"
           sh "$ENTWARE_URL"
         fi
 
         set -e
+        if ! verify_entware_install; then
+          return 0
+        fi
         ok_msg "Entware has been installed successfully!"
         echo -e "   Disconnect and reconnect SSH session, and you can now install packages with: ${yellow}opkg install <packagename>${white}"
         return;;

--- a/scripts/usb_camera.sh
+++ b/scripts/usb_camera.sh
@@ -77,24 +77,24 @@ aspect_ratio: 16:9
 EOF
 }
 
+# Makes mjpg-streamer available for the camera service this model actually runs.
+# Returns non-zero (after reporting) when it cannot; callers must check.
 function ensure_mjpg_streamer_packages(){
-  # K-series firmware already ships mjpg-streamer at /usr/bin (I tested this on my K1 Max and someone on discord checked on the K1C)
-  [ -x /usr/bin/mjpg_streamer ] && return
-
-  if "$ENTWARE_FILE" list | grep -q '^mjpg-streamer '; then
-    return
-  fi
-
   if [ "$model" = "K1_2025" ]; then
-    echo -e "Info: Updating Entware repository for mjpg-streamer packages..."
-    sed -i '1s|.*|src/gz entware http://bin.entware.net/mipselsf-k3.4|' /opt/etc/opkg.conf
-    "$ENTWARE_FILE" update
-  fi
-
-  if ! "$ENTWARE_FILE" list | grep -q '^mjpg-streamer '; then
-    error_msg "mjpg-streamer packages are not available in the configured Entware repository!"
+    # The 2025 camera services hardcode /usr/bin/mjpg_streamer and
+    # /usr/lib/mjpg-streamer, which the firmware supplies on a read-only
+    # squashfs. opkg writes to /opt and cannot help here.
+    [ -x /usr/bin/mjpg_streamer ] && return 0
+    error_msg "mjpg_streamer not found in firmware; this model requires it."
     return 1
   fi
+
+  # Legacy K1/3V3/3KE/10SE/E5M: the services read /opt/bin and /opt/lib, so
+  # Entware is the source and the package list must be current.
+  echo -e "Info: Updating Entware repository for mjpg-streamer packages..."
+  "$ENTWARE_FILE" update || { error_msg "Could not refresh the package list."; return 1; }
+  "$ENTWARE_FILE" install mjpg-streamer mjpg-streamer-input-http \
+    mjpg-streamer-input-uvc mjpg-streamer-output-http mjpg-streamer-www
 }
 
 function disable_entware_builtin_mjpg_streamer(){
@@ -130,6 +130,14 @@ function install_usb_camera(){
     case "${yn}" in
       Y|y)
         echo -e "${white}"
+        # Check packages before anything destructive: a failure here must leave
+        # the printer exactly as it was, and must return to the menu rather
+        # than propagate through helper.sh's global "set -e".
+        echo -e "Info: Checking necessary packages..."
+        if ! ensure_mjpg_streamer_packages; then
+          error_msg "USB Camera Support has not been installed!"
+          return 0
+        fi
         if [ "$model" = "K1_2025" ]; then
           k1_2025_migrate_entware_boot_if_needed
           disable_entware_builtin_mjpg_streamer
@@ -175,11 +183,6 @@ function install_usb_camera(){
           done
         fi
         chmod 755 "$USB_CAMERA_FILE"
-        echo -e "Info: Installing necessary packages..."
-        if [ ! -x /usr/bin/mjpg_streamer ]; then
-          ensure_mjpg_streamer_packages
-          "$ENTWARE_FILE" update && "$ENTWARE_FILE" install mjpg-streamer mjpg-streamer-input-http mjpg-streamer-input-uvc mjpg-streamer-output-http mjpg-streamer-www
-        fi
         if [ "$model" = "K1_2025" ]; then
           configure_usb_camera_k1_2025
           if [ -f "$INITD_FOLDER"/S56moonraker_service ]; then
@@ -212,6 +215,13 @@ function install_builtin_camera(){
     case "${yn}" in
       Y|y)
         echo -e "${white}"
+        # Same ordering rule as install_usb_camera: nothing destructive runs
+        # until the packages are known to be in place.
+        echo -e "Info: Checking necessary packages..."
+        if ! ensure_mjpg_streamer_packages; then
+          error_msg "Built-in Camera Fix has not been installed!"
+          return 0
+        fi
         k1_2025_migrate_entware_boot_if_needed
         disable_entware_builtin_mjpg_streamer
         echo -e "Info: Copying file..."
@@ -221,11 +231,6 @@ function install_builtin_camera(){
         rm -f "$BUILTIN_CAMERA_LEGACY_FILE"
         cp "$BUILTIN_CAMERA_K1_2025_URL" "$BUILTIN_CAMERA_FILE"
         chmod 755 "$BUILTIN_CAMERA_FILE"
-        echo -e "Info: Installing necessary packages..."
-        if [ ! -x /usr/bin/mjpg_streamer ]; then
-          ensure_mjpg_streamer_packages
-          "$ENTWARE_FILE" update && "$ENTWARE_FILE" install mjpg-streamer mjpg-streamer-input-http mjpg-streamer-input-uvc mjpg-streamer-output-http mjpg-streamer-www
-        fi
         configure_builtin_camera_k1_2025
         if [ -f "$INITD_FOLDER"/S56moonraker_service ]; then
           stop_moonraker


### PR DESCRIPTION
`ensure_mjpg_streamer_packages` decides whether to install mjpg-streamer by testing `/usr/bin/mjpg_streamer`, with no `$model` check, and `install_usb_camera` is wired into all six model menus. Only the K1 2025 camera services read `/usr/bin` and `/usr/lib`; the K1, 3V3, 3KE, 10SE and E5M services read `/opt/bin` and `/opt/lib`, which is Entware's territory, so on those five models the guard is testing a path their own service never looks at. This splits the check so each model is measured against the path it actually uses. Whether any legacy firmware ships `/usr/bin/mjpg_streamer` and therefore hits this in practice is not something I can check without that hardware, so this is a correctness fix rather than a reported bug.

The same function's failure path was unsafe. `helper.sh` sets `-e` and sources every script into one shell, so a `return 1` from a sourced function ends the whole program and drops the user to a prompt with no menu — and by the time the check ran, the working Entware streamer had already been stopped and renamed and the init script already copied into place, with nothing left running to undo any of it. The check now runs before anything destructive and its status is handled at both call sites, so a failure reports the reason and returns to the menu with the printer in the state it started in.

Removing that path also removed both `sed`s that rewrote `/opt/etc/opkg.conf`, and those seds were the only thing still repairing printers left pointing at `bin.tranducanh.com` after that host stopped serving the repository. Since `/opt/etc/opkg.conf` lives on the printer's persistent `/opt` and no helper-script update touches it, those printers would have been stranded with no way back. In their place is a deliberate one-shot migration at startup: it matches on the hostname rather than a line number so anything the user added to the file survives, writes through a temp file and only swaps it in once complete so a full `/opt` image cannot leave a truncated config behind, and prints a one-time notice naming `opkg update` as the follow-up, since rewriting the config does not refresh a package index from March 2024. It cannot fail the script.

Finally, `install_entware` ran its whole body under `set +e` and then printed a green checkmark regardless of the outcome, symlinking `/opt/libexec/sftp-server` whether or not the install had produced it — so a failed install reported success and left SFTP broken behind a dangling symlink. It now checks that the install produced what the rest of the script depends on before saying so, and guards the symlink the same way the `S48entware` boot script it writes already does. The `prepare_opt` call in that function was removed in 7a6ebfa and has not existed since; it was harmless, because `files/entware/generic.sh` creates the same directories, but `set +e` was hiding a `command not found` on every legacy install.

These four changes have to land together. The first two delete the seds, and the third is what replaces them.

## Test plan

- [x] `shellcheck -s bash -S warning -e SC2154,SC2034,SC1090,SC1091,SC1111` on the three changed files introduces no new findings (the three that remain are pre-existing: the duplicated `1080p` case pattern and one SC2155 in `helper.sh`)
- [x] `bash -n` parses every script in the repo
- [x] Stub harness against the real functions: a failed camera install returns to the menu with `helper.sh` still running, leaves `S96mjpg-streamer` enabled, and runs no destructive step first; the legacy path issues exactly one `opkg update` and one package install; `usb_camera.sh` no longer references `opkg.conf` on any path
- [x] Stub harness for the migration: rewrites only the dead hostname, preserves user-added `src/gz` and non-feed directives verbatim, stays silent when there is nothing to do, and is a no-op on second run
- [x] Migration against a genuinely full filesystem (1 MB volume filled to 0 KB free): the original config is left byte-identical, no partial temp file survives, and the failure is reported
- [ ] Manual test pass (see checklist below)

The harness above is a local scratch script, not part of this PR; a test directory is a separate change.

## Manual test pass

- [ ] On a K1 2025, `head -1 /opt/etc/opkg.conf` reads `bin.entware.net` both before and after a USB camera install
- [ ] Rename `/usr/bin/mjpg_streamer`, run a USB camera install, and confirm you land back in the helper menu rather than a shell prompt
- [ ] After that failed install, `/opt/etc/init.d/S96mjpg-streamer` is still enabled and `/opt/etc/opkg.conf` is unchanged
- [ ] Restore `/usr/bin/mjpg_streamer`, install the built-in camera fix, and confirm the stream comes up in Fluidd
- [ ] On a printer still pointed at `bin.tranducanh.com`, launch the helper and confirm the notice appears once, the config is rewritten, and the notice does not return on the next launch
- [ ] Reinstall Entware and confirm `ls -l /usr/libexec/sftp-server` resolves to a real file
- [ ] On a legacy model, install USB camera support and confirm the mjpg-streamer packages land in `/opt/bin`

## Not addressed

The duplicated `1080p|1080p` case pattern that silently rejects `1080P`, and the plain-HTTP fallback in `files/entware/generic.sh` that downloads and root-executes `opkg` from a third-party host, are both real but unrelated to this change and belong in their own PRs. The redundant `disable_entware_builtin_mjpg_streamer` call in `install_builtin_camera` is left alone too — the shipped service redoes that work on every start anyway, and untangling it would widen this diff.
