### PR TITLE
Allow Restore Input Shapers on firmware V1.0.0.23 and V1.0.0.26

### DIFF
--- a/scripts/restore_input_shapers.sh
+++ b/scripts/restore_input_shapers.sh
@@ -8,7 +8,7 @@ set -e
 # of the reported firmware (check_fw_version, which returns /etc/version on the
 # K1_2025). Space-separated; extend as builds are confirmed. Anyone on an unlisted
 # build is asked to report it first rather than have klippy touched blindly.
-RESTORE_SHAPERS_SUPPORTED_FW="V1.0.0.22.20250711S"
+RESTORE_SHAPERS_SUPPORTED_FW="V1.0.0.22.20250711S V1.0.0.26.20251024S"
 
 function restore_input_shapers_message(){
   top_line

--- a/scripts/restore_input_shapers.sh
+++ b/scripts/restore_input_shapers.sh
@@ -2,13 +2,14 @@
 
 set -e
 
-# Firmware builds whose stock Klipper this restore is verified against. A future
-# Creality firmware could ship a different shaper_defs (or react differently to the
-# change), so klippy is only modified on known-good versions, matched as a substring
-# of the reported firmware (check_fw_version, which returns /etc/version on the
-# K1_2025). Space-separated; extend as builds are confirmed. Anyone on an unlisted
-# build is asked to report it first rather than have klippy touched blindly.
-RESTORE_SHAPERS_SUPPORTED_FW="V1.0.0.22.20250711S V1.0.0.26.20251024S"
+# Firmware builds this restore is known-good on. A future Creality firmware could
+# ship a different shaper_defs (or react differently to the change), so klippy is
+# only modified on listed versions, matched as a substring of the reported firmware
+# (check_fw_version, which returns /etc/version on the K1_2025). Space-separated;
+# extend as builds are confirmed. Heads-up: .23 was never run on hardware, it is
+# listed because its Klipper bytecode is identical to the verified .22. Anyone on an
+# unlisted build is asked to report it first rather than have klippy touched blindly.
+RESTORE_SHAPERS_SUPPORTED_FW="V1.0.0.22.20250711S V1.0.0.23.20250722S V1.0.0.26.20251024S"
 
 function restore_input_shapers_message(){
   top_line


### PR DESCRIPTION
Restore Input Shapers refuses to install on any firmware outside a hard-coded allowlist, so K1C-2025 owners on newer builds hit a bail-out even where the restore is fine. This adds two builds to that list.

`V1.0.0.26.20251024S` rests on a user report: they removed the gate locally and reported the feature working. Not reproduced here.

`V1.0.0.23.20250722S` has never been run on hardware by anyone. It is listed on bytecode identity with the hardware-verified `.22` instead. Creality's signed vendor OTA for `.23` (`CR4SU200382C13_ota_K1C-2025_V1.0.0.23.20250722S.img`, verifying clean across 11 CRC32s plus an RSASSA-PSS signature) ships `shaper_defs`, `shaper_calibrate`, `input_shaper` and `resonance_tester` `.pyc` byte-identical to `.22` under normalised CPython-3.8 digests, with `co_filename` and header mtime excluded so build-host noise is factored out. That is a tighter match than the `.26` in this same PR, whose `resonance_tester` is the one module that does differ.

The preconditions the restore actually depends on were read off the `.23` image rather than inferred from those digests: `INPUT_SHAPERS` trimmed to a single `ei` entry, `axis_x_use_y` present in `resonance_tester`, CPython 3.8, and no `.py` files or `__pycache__` under `klippy/extras` — so a dropped `shaper_defs.py` shadows the legacy `.pyc` with nothing left to evict. The five feature-flag modules `.26` introduced are absent from `.23`, so no new gating layer sits between `.22` and `.23` that could reach this code.

The header comment above the list used to describe all of it as "verified against". With `.23` in there that one word would span two unequal grades of evidence, so the comment now flags the distinction in a line.

## Test plan
- [x] `sh -n scripts/restore_input_shapers.sh` passes
- [x] Gate loop exercised against real `/etc/version` strings: `.22`, `.23` and `.26` all match; a same-date-different-point build (`V1.0.0.24.20250722S`), `N/A` and empty still bail out
- [ ] Manual test pass (see checklist below)

## Manual test pass
- [ ] On a `.23` box, run Install — expect it to proceed rather than bail, then `SHAPER_CALIBRATE` and confirm it fits the full model set (zv/mzv/ei/2hump_ei/3hump_ei), not only `ei`
- [ ] On a `.23` box, confirm `axis_x_use_y: false` lands under `[resonance_tester]` in printer.cfg and that X and Y calibrate independently
- [ ] On a `.26` box, repeat both checks to put the user report on first-hand footing
- [ ] On either box, run Remove — expect `shaper_defs.py` gone, `axis_x_use_y` stripped from printer.cfg, and Klipper restarting clean

## Not addressed
Every future firmware still needs its own entry here. No prefix or range matching was introduced, since the point of the gate is that each build gets looked at before klippy is touched.
