### PR TITLE
Add an Extended Gcode Params option so filenames with #, ; or * can be printed

### DIFF
--- a/files/extended-gcode-params/extended_gcode_params.py
+++ b/files/extended-gcode-params/extended_gcode_params.py
@@ -1,0 +1,142 @@
+# Backport of upstream Klipper's extended-parameter parser to Creality's klippy.
+#
+# Deploys to: /usr/share/klipper/klippy/extras/extended_gcode_params.py
+# Enabled by: a bare `[extended_gcode_params]` section in printer.cfg
+# Needed on:  the K1C 2025 and the K1/K1C OG alike. The 2025 cannot pass '#',
+#             ';' or '*'; the OG has a Creality fix for '#' and ';' that breaks
+#             '|' instead. Neither is upstream's, and upstream's handles all four.
+#
+# WHAT THIS IS
+# ------------
+# Klipper fixed this upstream in PR #6749 ("gcode: Improve handling of extended
+# g-code commands with '*;#' characters", Kevin O'Connor), merged 2024-12-01 as
+# 2165c90. This module is that fix, ported verbatim, installed at runtime.
+#
+# The 2025's `gcode.pyc` best-fits upstream at **2024-11-26** (k25_sweep.json,
+# 4 fitting revisions of 235) -- five days before the fix landed. So this is not
+# Creality breaking something: it is a fork taken from upstream days before
+# upstream fixed it, frozen there ever since. `gcode.pyc` is byte-identical
+# between the installed V1.0.0.22 and the pending V1.0.0.26, so no vendor update
+# will deliver it.
+#
+# THE BUG
+# -------
+# The old parser found the argument text with a regex that treats '#', '*' and
+# ';' as comment characters, quotes or no quotes:
+#
+#     (?P<args>[^#*;]*?)\s*(?:[#*;].*)?$
+#
+# Because the group is non-greedy it stops at the FIRST such character, which
+# inside `FILENAME="..."` is always after the opening quote and before the
+# closing one. The quote is left unbalanced, `shlex` raises, and Klipper reports
+# `Malformed command`. On Creality's builds that surfaces on the panel as the
+# information-free `XS2000`.
+#
+# Upstream's fix hands the raw parameter text to `shlex` and lets shlex do the
+# comment stripping, because shlex knows what a quote is:
+#
+#     s = shlex.shlex(rawparams, posix=True)
+#     s.whitespace_split = True
+#     s.commenters = '#;'
+#
+# Comments outside quotes still work; everything inside quotes is literal. '*'
+# stops being a comment character here entirely -- upstream moved checksum
+# handling into `get_raw_command_parameters()`, where it belongs, since '*NNN'
+# is only a checksum on a line-numbered line.
+#
+# WHY A RUNTIME PATCH AND NOT AN EDIT TO gcode.pyc
+# ------------------------------------------------
+# `gcode.py` is on the encrypted/compiled tier and is core command dispatch. The
+# extras directory, by contrast, is `ext4 (rw)` on mmcblk0p8 and already holds
+# two files this repo ships (`gcode_shell_command.py`, `shaper_defs.py`).
+#
+# The patch point works because of how Klipper wraps extended commands:
+#
+#     func = lambda params: origfunc(self._get_extended_params(params))
+#
+# That resolves `_get_extended_params` through the INSTANCE on every command, so
+# binding a replacement onto the gcode object catches every extended command,
+# including ones registered before this module loaded. Ordering is irrelevant,
+# so there are no config placement rules.
+#
+# ⚠ DO NOT "SIMPLIFY" THIS BY EDITING THE REGEX IN gcode.pyc.
+# Swapping the comment class in place is even length-preserving, which makes it
+# look free. It is not: `get_commandline()` returns the line INCLUDING its
+# trailing ';' comment, so ';' must stay a comment character for every other
+# extended command, or an ordinary line like
+#     SET_HEATER_TEMPERATURE HEATER=extruder TARGET=200 ; heat it up
+# starts failing. That is why the OG's own fix added a SECOND regex rather than
+# widening the first, and why upstream moved to shlex instead of either.
+#
+# WHAT CHANGES, HONESTLY
+# ----------------------
+# This is a behaviour change, not a pure widening, and the difference is '*'.
+# Under the old parser `FOO A=1*2` yielded `{A: '1'}`; under upstream's it
+# yields `{A: '1*2'}`. That is upstream's deliberate choice -- a trailing '*NNN'
+# is a checksum only on a line-numbered line, and it is handled there. Every
+# other divergence from the old parser is strictly "a line that used to fail now
+# succeeds"; `test_extended_gcode_params.py` characterises all of them against a
+# model of the old parser rather than leaving them to be discovered.
+#
+# KNOWN LIMIT
+# -----------
+# Upstream's commit 7 ("Improve checksum detection in
+# get_raw_command_parameters") only treats a trailing '*' as a checksum when the
+# rest is digits. Both printers predate that, and their
+# `get_raw_command_parameters` is otherwise identical to current upstream. So a
+# LINE-NUMBERED command with '*' in a quoted argument -- `N42 SDCARD_PRINT_FILE
+# FILENAME="a*b.gcode"` -- still truncates. Not reachable from Moonraker, which
+# never sends line numbers, and not fixable from here without also rebinding
+# GCodeCommand.get_raw_command_parameters. Recorded rather than fixed.
+import logging
+import shlex
+
+# Upstream's comment characters for extended parameters. '*' is deliberately
+# absent -- see the header.
+COMMENTERS = '#;'
+
+
+def parse_params(rawparams):
+    """Upstream's parameter extraction, verbatim in behaviour.
+
+    Returns the params dict, or raises ValueError exactly where upstream's
+    `_get_extended_params` would raise `Malformed command`.
+
+    Pure and side-effect free on purpose: this is the whole of the fix, and it
+    is testable without a printer, a gcode object or a GCodeCommand.
+    """
+    s = shlex.shlex(rawparams, posix=True)
+    s.whitespace_split = True
+    s.commenters = COMMENTERS
+    return {k.upper(): v for k, v in (arg.split('=', 1) for arg in s)}
+
+
+class ExtendedGCodeParams:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        gcode = self.printer.lookup_object('gcode')
+        stock = getattr(gcode, '_get_extended_params', None)
+        if stock is None:
+            logging.warning(
+                "extended_gcode_params: gcode object has no "
+                "_get_extended_params; leaving the stock parser alone")
+            return
+
+        def _get_extended_params(gcmd):
+            try:
+                eparams = parse_params(gcmd.get_raw_command_parameters())
+            except ValueError:
+                # Unbalanced quotes, or a token with no '='. Hand it back to the
+                # stock parser so the rejection keeps stock wording -- which on
+                # Creality's builds is what the error_code table is keyed on.
+                return stock(gcmd)
+            gcmd._params.clear()
+            gcmd._params.update(eparams)
+            return gcmd
+
+        gcode._get_extended_params = _get_extended_params
+        logging.info("extended_gcode_params: upstream PR #6749 parser installed")
+
+
+def load_config(config):
+    return ExtendedGCodeParams(config)

--- a/scripts/extended_gcode_params.sh
+++ b/scripts/extended_gcode_params.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+
+set -e
+
+function extended_gcode_params_message(){
+  top_line
+  title 'Extended Gcode Params' "${yellow}"
+  inner_line
+  hr
+  echo -e " │ ${cyan}Klipper's extended g-code parser treats '#', ';' and '*' as  ${white}│"
+  echo -e " │ ${cyan}comment characters even inside quotes, so a gcode file with  ${white}│"
+  echo -e " │ ${cyan}one in its name cannot be printed from the web interface.    ${white}│"
+  echo -e " │ ${cyan}This installs upstream's fixed parser (Klipper PR #6749).    ${white}│"
+  hr
+  bottom_line
+}
+
+function install_extended_gcode_params(){
+  extended_gcode_params_message
+  local yn
+  while true; do
+    install_msg "Extended Gcode Params" yn
+    case "${yn}" in
+      Y|y)
+        echo -e "${white}"
+        echo -e "Info: Linking file..."
+        ln -sf "$EXTENDED_GCODE_PARAMS_URL" "$KLIPPER_EXTRAS_FOLDER"/extended_gcode_params.py
+        # Unlike Gcode Shell Command, this extra does nothing until a bare
+        # [extended_gcode_params] section exists in printer.cfg — the module is
+        # only loaded by klippy when its section is present.
+        if grep -q "^\[extended_gcode_params\]" "$PRINTER_CFG" ; then
+          echo -e "Info: Extended Gcode Params is already enabled in printer.cfg file..."
+        else
+          # Klipper owns everything below the SAVE_CONFIG marker and rewrites it,
+          # so the section goes in above the marker on any printer that has ever
+          # run SAVE_CONFIG, and at the end of the file on one that has not.
+          echo -e "Info: Adding Extended Gcode Params configuration in printer.cfg file..."
+          awk '!added && /^#\*#.*SAVE_CONFIG/ { if (prev != "") print ""; print "[extended_gcode_params]"; print ""; added=1 } { print; prev=$0 } END { if (!added) { if (prev != "") print ""; print "[extended_gcode_params]" } }' "$PRINTER_CFG" > "$PRINTER_CFG.hs_tmp" && cat "$PRINTER_CFG.hs_tmp" > "$PRINTER_CFG" && rm -f "$PRINTER_CFG.hs_tmp"
+        fi
+        echo -e "Info: Restarting Klipper service..."
+        restart_klipper
+        # The extra registers no status fields, so it never appears in the Klipper
+        # API method "objects/list" — checking that list reports a working module as
+        # missing. Klippy reaching "ready" with the section present is the load
+        # proof, since an unfindable module is a config error rather than a ready
+        # state. klippy.log also carries "upstream PR #6749 parser installed".
+        ok_msg "Extended Gcode Params has been installed successfully!"
+        echo -e " ${cyan}Gcode files with ${white}#${cyan}, ${white};${cyan} or ${white}*${cyan} in their name can now be printed.${white}"
+        return;;
+      N|n)
+        error_msg "Installation canceled!"
+        return;;
+      *)
+        error_msg "Please select a correct choice!";;
+    esac
+  done
+}
+
+function remove_extended_gcode_params(){
+  extended_gcode_params_message
+  local yn
+  while true; do
+    remove_msg "Extended Gcode Params" yn
+    case "${yn}" in
+      Y|y)
+        echo -e "${white}"
+        # Remove the config section before the module, so klippy is never restarted
+        # with a section it has no extra for.
+        if grep -q "^\[extended_gcode_params\]" "$PRINTER_CFG" ; then
+          echo -e "Info: Removing Extended Gcode Params configuration in printer.cfg file..."
+          # Drops the blank line the installer put after the section too, so an
+          # install/remove cycle on a printer that has run SAVE_CONFIG leaves
+          # printer.cfg byte-identical rather than growing a blank line each time.
+          awk '/^\[extended_gcode_params\]/ { skip=1; next } skip && /^$/ { skip=0; next } { skip=0; print }' "$PRINTER_CFG" > "$PRINTER_CFG.hs_tmp" && cat "$PRINTER_CFG.hs_tmp" > "$PRINTER_CFG" && rm -f "$PRINTER_CFG.hs_tmp"
+        else
+          echo -e "Info: Extended Gcode Params configurations are already removed in printer.cfg file..."
+        fi
+        echo -e "Info: Removing files..."
+        rm -f "$KLIPPER_EXTRAS_FOLDER"/extended_gcode_params.py
+        rm -f "$KLIPPER_EXTRAS_FOLDER"/extended_gcode_params.pyc
+        rm -f "$KLIPPER_EXTRAS_FOLDER"/__pycache__/extended_gcode_params.*pyc 2>/dev/null || true
+        echo -e "Info: Restarting Klipper service..."
+        restart_klipper
+        ok_msg "Extended Gcode Params has been removed successfully!"
+        return;;
+      N|n)
+        error_msg "Deletion canceled!"
+        return;;
+      *)
+        error_msg "Please select a correct choice!";;
+    esac
+  done
+}

--- a/scripts/menu/K1_2025/info_menu_K1C_2025.sh
+++ b/scripts/menu/K1_2025/info_menu_K1C_2025.sh
@@ -84,6 +84,7 @@ function info_menu_ui_k1_2025() {
   info_line "$(check_file_k1_2025 "$FAN_CONTROLS_FILE")" 'Fans Control Macros'
   info_line "$(check_folder_k1_2025 "$IMP_SHAPERS_FOLDER")" 'Improved Shapers Calibrations'
   info_line "$(check_file_k1_2025 "$SHAPER_DEFS_FILE")" 'Restore Input Shapers'
+  info_line "$(check_file_k1_2025 "$EXTENDED_GCODE_PARAMS_FILE")" 'Extended Gcode Params'
   info_line "$(check_file_k1_2025 "$USEFUL_MACROS_FILE")" 'Useful Macros'
   info_line "$(check_file_k1_2025 "$SAVE_ZOFFSET_FILE")" 'Save Z-Offset Macros'
   info_line "$(check_file_k1_2025 "$SCREWS_ADJUST_FILE")" 'Screws Tilt Adjust Support'

--- a/scripts/menu/K1_2025/install_menu_K1C_2025.sh
+++ b/scripts/menu/K1_2025/install_menu_K1C_2025.sh
@@ -25,6 +25,7 @@ function install_menu_ui_k1_2025() {
   hr
   subtitle '•IMPROVEMENTS:'
   menu_option '11' 'Install' 'Restore Input Shapers'
+  menu_option '12' 'Install' 'Extended Gcode Params'
 #  hr
 #  subtitle '•IMPROVEMENTS:'
 #  disabled_menu_option ' 6' 'Install' 'Klipper Adaptive Meshing & Purging'
@@ -162,6 +163,12 @@ function install_menu_k1_2025() {
           error_msg "Restore Input Shapers is already installed!"
         else
           run "install_restore_input_shapers" "install_menu_ui_k1_2025"
+        fi;;
+      12)
+        if [ -f "$EXTENDED_GCODE_PARAMS_FILE" ]; then
+          error_msg "Extended Gcode Params is already installed!"
+        else
+          run "install_extended_gcode_params" "install_menu_ui_k1_2025"
         fi;;
 #      7)
 #        disabled_feature;;

--- a/scripts/menu/K1_2025/remove_menu_K1C_2025.sh
+++ b/scripts/menu/K1_2025/remove_menu_K1C_2025.sh
@@ -25,6 +25,7 @@ function remove_menu_ui_k1_2025() {
   hr
   subtitle '•IMPROVEMENTS:'
   menu_option '11' 'Remove' 'Restore Input Shapers'
+  menu_option '12' 'Remove' 'Extended Gcode Params'
 #  hr
 #  subtitle '•IMPROVEMENTS:'
 #  disabled_menu_option ' 6' 'Remove' 'Klipper Adaptive Meshing & Purging'
@@ -167,6 +168,12 @@ function remove_menu_k1_2025() {
           error_msg "Restore Input Shapers is not installed!"
         else
           run "remove_restore_input_shapers" "remove_menu_ui_k1_2025"
+        fi;;
+      12)
+        if [ ! -f "$EXTENDED_GCODE_PARAMS_FILE" ]; then
+          error_msg "Extended Gcode Params is not installed!"
+        else
+          run "remove_extended_gcode_params" "remove_menu_ui_k1_2025"
         fi;;
 
 #      6)

--- a/scripts/paths.sh
+++ b/scripts/paths.sh
@@ -90,7 +90,11 @@ function set_paths() {
   # Klipper Gcode Shell Command #
   KLIPPER_SHELL_FILE="${KLIPPER_EXTRAS_FOLDER}/gcode_shell_command.py"
   KLIPPER_SHELL_URL="${HS_FILES}/gcode-shell-command/gcode_shell_command.py"
-  
+
+  # Extended Gcode Params #
+  EXTENDED_GCODE_PARAMS_FILE="${KLIPPER_EXTRAS_FOLDER}/extended_gcode_params.py"
+  EXTENDED_GCODE_PARAMS_URL="${HS_FILES}/extended-gcode-params/extended_gcode_params.py"
+
   # Klipper Adaptive Meshing & Purging #
   KAMP_FOLDER="${HS_CONFIG_FOLDER}/KAMP"
   KAMP_URL="${HS_FILES}/kamp"


### PR DESCRIPTION
A gcode file with a `#`, `;` or `*` in its name cannot be printed from the web UI on the K1C 2025. `SDCARD_PRINT_FILE FILENAME="..."` is an extended g-code command, and Klipper finds the argument text of those with a regex that treats all three as comment characters whether or not they are quoted. The group is non-greedy, so it stops at the first one, which inside `FILENAME="My Model #2.gcode"` is always after the opening quote and before the closing one. `shlex` is handed an unbalanced quote and rejects it, which Fluidd's Jobs tab surfaces as `XS2000 / Malformed command`.

Klipper fixed this upstream in PR #6749, merged 2024-12-01 as `2165c90`, by parsing the quoted string properly instead of pre-stripping comment characters. No firmware update will deliver it here. The 2025's `gcode.pyc` best-fits upstream at 2024-11-26, five days before that fix landed, and the file is byte-identical between V1.0.0.22 and the pending V1.0.0.26. This is not Creality breaking something; it is a fork taken from upstream days before upstream fixed it and frozen there since.

This adds upstream's parser as an optional klippy extra, in the same install/remove shape as Klipper Gcode Shell Command and guarded in the menus exactly as entry 5 guards it. Nothing in the vendor tree is edited or shadowed. The module rebinds `_get_extended_params` on the gcode object, which catches every extended command including those registered before it loaded, because Klipper resolves that attribute through the instance on each call. Ordering is irrelevant, so there are no config placement rules.

The one place this differs from Gcode Shell Command is worth your eye. That extra loads from the file alone; this one needs a bare `[extended_gcode_params]` section in `printer.cfg` or it sits inert, so the installer has to edit `printer.cfg`. The existing pattern for that does not work on this machine: `buzzer_support.sh` anchors its `sed` to `[include printer_params.cfg]`, and the 2025's `printer.cfg` has no such line, so that `sed` would match nothing, change nothing, and still report success. A blind append is also wrong, because Klipper owns and rewrites everything below `#*# <---------------------- SAVE_CONFIG ---------------------->` and the section would land inside that block on any printer that has ever been levelled. The installer therefore inserts above the marker when it is present and appends when it is not, and the remover strips the section and the blank line the installer added so repeated install/remove cycles leave `printer.cfg` byte-identical rather than growing whitespace.

Two behaviour notes. Adopting upstream's parser means `*` is no longer a comment character in extended parameters, so `FOO A=1*2` now yields `A=1*2` where the old parser gave `A=1`; that is upstream's deliberate choice, since a trailing `*NNN` is a checksum only on a line-numbered line and is handled there. And these builds predate upstream's later checksum-detection improvement, so a line-numbered command with `*` in a quoted argument still truncates. Moonraker never sends line numbers, so that path is not reachable from the web UI.

On scope: the `#`, `;` and `*` failures are measured on the K1C 2025. The K1/K1C OG under Guilouz's script is affected too but by a different character, because Creality patched `#` and `;` there and the patch breaks `|` instead. Neither fork's parser is upstream's and upstream's handles all four. I have kept the menu entry 2025-only since that is what this repo serves, but whether it belongs elsewhere is your call rather than mine. Ordinary filenames are unaffected either way; this is specifically the extended-command argument path.

The Shellcheck workflow will go red on this PR, but not because of it: 76 of the 78 `.sh` files already on `main` fail `shellcheck`, and the new script emits the same four codes (SC2112, SC2154, SC3037, SC3043) as the scripts it is modelled on.

## Not addressed

The Guilouz fork has the same class of bug on `|` and is a separate repo, so it is left alone here.

## Test plan

- [x] `sh -n` clean on the new script and the four edited files
- [x] `printer.cfg` insertion exercised against fixtures with the SAVE_CONFIG marker present, absent, and as the first line, including repeated install/remove cycles
- [x] Parser driven against a stand-in gcode object: `#`, `;`, `*` and `|` filenames parse, out-of-quote `;`/`#` comments still strip, and malformed input still falls back to the stock rejection so the wording the error_code table is keyed on is preserved
- [ ] Manual test pass (see checklist below)

The automated boxes were run against this checkout on a workstation, not a printer. The hardware evidence below is from my own machines on an earlier build of the same module: deployed to a K1C OG on 2026-08-15 and a K1C 2025 on 2026-08-17, both klippy instances came back `ready` and logged the load line, and both printed real files whose names carry the offending character: `SS Puppet Theatre-10h42m-0.4w-0.12h#.gcode` on the 2025, `SS Crate Stacks Mir-12h41m-0.4w-0.16h*.gcode` on the OG. The same files gave `XS2000 / Malformed command` before. None of that was re-run from this branch, so the boxes below are unticked.

## Manual test pass

- [ ] Install from the menu, then check `extended_gcode_params.py` is linked into klippy extras and `[extended_gcode_params]` is in `printer.cfg` above the SAVE_CONFIG marker
- [ ] Klipper restarts to `ready`, and `klippy.log` carries `extended_gcode_params: upstream PR #6749 parser installed`. The extra registers no status fields, so it does not appear in `objects/list`, which reports a working module as missing
- [ ] Upload and print a file with `#` in its name from the web UI: it starts, no XS2000
- [ ] Remove from the menu, then check the module and the config section are both gone and Klipper is still `ready`
